### PR TITLE
Update LCU connection check

### DIFF
--- a/biz/lcu/monitor.go
+++ b/biz/lcu/monitor.go
@@ -7,23 +7,29 @@ import (
 
 // WatchLogin periodically checks login status and notifies via callback when it changes.
 func WatchLogin(ctx context.Context, interval time.Duration, cb func(bool)) {
-	go func() {
-		ticker := time.NewTicker(interval)
-		defer ticker.Stop()
-		prev := false
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-ticker.C:
-				curr := CheckLogin()
-				if curr != prev {
-					prev = curr
-					if cb != nil {
-						cb(curr)
-					}
-				}
-			}
-		}
-	}()
+        go func() {
+                ticker := time.NewTicker(interval)
+                defer ticker.Stop()
+
+                // send initial status
+                prev := CheckLogin()
+                if cb != nil {
+                        cb(prev)
+                }
+
+                for {
+                        select {
+                        case <-ctx.Done():
+                                return
+                        case <-ticker.C:
+                                curr := CheckLogin()
+                                if curr != prev {
+                                        prev = curr
+                                        if cb != nil {
+                                                cb(curr)
+                                        }
+                                }
+                        }
+                }
+        }()
 }

--- a/frontend/src/views/home/components/ConnectionStatus.vue
+++ b/frontend/src/views/home/components/ConnectionStatus.vue
@@ -1,8 +1,11 @@
 <template>
   <div class="conn-status">
-    <a-tag :color="online ? 'green' : 'red'">
-      {{ online ? "已连接LCU" : "未连接" }}
-    </a-tag>
+    <template v-if="online">
+      <a-tag color="green">已连接LCU</a-tag>
+    </template>
+    <template v-else>
+      <span class="waiting">等待连接</span>
+    </template>
   </div>
 </template>
 
@@ -17,5 +20,28 @@ const online = computed(() => appStore.lcuOnline);
 <style scoped>
 .conn-status {
   padding: 8px;
+}
+.waiting {
+  display: inline-block;
+  position: relative;
+  padding-right: 1.4em;
+}
+.waiting::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 0;
+  width: 0.8em;
+  height: 0.8em;
+  margin-top: -0.4em;
+  border: 2px solid var(--color-neutral-6);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 </style>

--- a/frontend/src/views/home/components/Welcome.vue
+++ b/frontend/src/views/home/components/Welcome.vue
@@ -16,7 +16,13 @@
               appStore.sysTime ? appStore.sysTime[0] : "---"
             }}</span>
           </p>
-          <p>客户端路径：{{ appStore.clientPath || "未找到" }}</p>
+          <p>
+            客户端路径：{{ appStore.clientPath || "未找到" }}
+            <span class="status">
+              <a-tag v-if="appStore.lcuOnline" color="green">已连接LCU</a-tag>
+              <span v-else class="waiting">等待连接</span>
+            </span>
+          </p>
         </div>
       </a-space>
     </a-row>
@@ -52,6 +58,32 @@ const userStore = useUserStore();
         font-size: 1.25rem;
         color: var(--color-neutral-8);
         margin-bottom: 10px;
+      }
+      .status {
+        margin-left: 8px;
+      }
+      .waiting {
+        display: inline-block;
+        position: relative;
+        padding-right: 1.4em;
+      }
+      .waiting::after {
+        content: "";
+        position: absolute;
+        top: 50%;
+        right: 0;
+        width: 0.8em;
+        height: 0.8em;
+        margin-top: -0.4em;
+        border: 2px solid var(--color-neutral-6);
+        border-top-color: transparent;
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- emit initial LCU status when watching connection
- show connection status beside client path on startup
- add animated waiting indicator when not connected

## Testing
- `npm run build` *(fails: vite not found)*
- `go vet ./...` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855674f15a4832d8592f2ad0a8ef1ca