### PR TITLE
Expose API routes via gin server

### DIFF
--- a/api.go
+++ b/api.go
@@ -1,0 +1,43 @@
+package Soraka
+
+import "github.com/gin-gonic/gin"
+
+// Api defines HTTP handlers used by the frontend.
+type Api struct{}
+
+func (a *Api) DevHand(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "dev"})
+}
+
+// ProphetActiveMid is a placeholder middleware.
+func (a *Api) ProphetActiveMid(c *gin.Context) {
+	c.Next()
+}
+
+func (a *Api) QueryHorseBySummonerName(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "query horse by summoner"})
+}
+
+func (a *Api) GetAllConf(c *gin.Context) {
+	c.JSON(200, gin.H{"config": "all"})
+}
+
+func (a *Api) UpdateClientConf(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "update ok"})
+}
+
+func (a *Api) GetLcuAuthInfo(c *gin.Context) {
+	c.JSON(200, gin.H{"auth": "info"})
+}
+
+func (a *Api) GetAppInfo(c *gin.Context) {
+	c.JSON(200, gin.H{"app": "info"})
+}
+
+func (a *Api) CopyHorseMsgToClipBoard(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "copied"})
+}
+
+func (a *Api) LcuProxy(c *gin.Context) {
+	c.JSON(200, gin.H{"message": "proxy"})
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,7 +6,10 @@ import (
 	"log"
 	"time"
 
+	"github.com/gin-gonic/gin"
 	"github.com/wailsapp/wails/v3/pkg/application"
+
+	"Soraka"
 )
 
 // 前端构建产物
@@ -67,6 +70,16 @@ func main() {
 		mainWin.Show()
 		mainWin.Focus()
 	})
+
+	// start API server for frontend calls
+	go func() {
+		r := gin.Default()
+		api := &Soraka.Api{}
+		Soraka.RegisterRoutes(r, api)
+		if err := r.Run(":8200"); err != nil {
+			log.Fatal(err)
+		}
+	}()
 
 	// 每秒发送时间事件
 	go func() {


### PR DESCRIPTION
## Summary
- add stub `Api` handlers
- start gin server in `main` and register routes

## Testing
- `go test ./...` *(fails: Forbidden due to network restriction)*

------
https://chatgpt.com/codex/tasks/task_e_6855d3ab08d0832da169399e98a7708d