### PR TITLE
Update frontend API usage

### DIFF
--- a/frontend/src/api/lcu.ts
+++ b/frontend/src/api/lcu.ts
@@ -1,0 +1,27 @@
+import { defHttp } from '@/utils/http';
+
+export interface AuthInfo {
+  port: number;
+  token: string;
+}
+
+// 获取LCU登录信息
+export function getLcuAuthInfo() {
+  return defHttp.post<AuthInfo>({ url: '/v1/lcu/getAuthInfo' });
+}
+
+// 通过后端代理获取当前召唤师信息
+export interface SummonerInfo {
+  displayName: string;
+  profileIconId: number;
+  region: string;
+}
+
+export function getCurrentSummoner() {
+  return defHttp.get<SummonerInfo>({ url: '/v1/lcu/proxy/lol-summoner/v1/current-summoner' });
+}
+
+// 启动LOL客户端
+export function startClient() {
+  return defHttp.post({ url: '/v1/client/start' });
+}

--- a/frontend/src/views/home/components/quick-operation.vue
+++ b/frontend/src/views/home/components/quick-operation.vue
@@ -48,7 +48,7 @@
 import {onMounted } from 'vue';
 import { Notification, Message } from '@arco-design/web-vue';
 import {WML} from "@wailsio/runtime";
-import { ClientService } from "/#/Soraka/service";
+import { startClient } from "@/api/lcu";
 onMounted(async()=>{
     WML.Reload()
 })
@@ -71,13 +71,8 @@ onMounted(async()=>{
         })
     } else if(val=="startclient") {
         Message.loading({content:'启动中，请稍后', id:'startclient', duration:0})
-        ClientService.StartClient().then((err:string)=>{
-            if(err){
-                Notification.error({title:'启动失败',content:err,position:'bottomRight'})
-                Message.error({content:'启动失败', id:'startclient', duration:2000})
-            }else{
-                Message.success({content:'启动成功', id:'startclient', duration:2000})
-            }
+        startClient().then(() => {
+            Message.success({content:'启动成功', id:'startclient', duration:2000})
         }).catch((e:any)=>{
             Notification.error({title:'启动失败',content:String(e),position:'bottomRight'})
             Message.error({content:'启动失败', id:'startclient', duration:2000})


### PR DESCRIPTION
## Summary
- add API helpers for LCU requests
- update AppSider to fetch summoner info through new APIs
- update home components to use HTTP APIs

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855d77c5038832db431832490dfba64