### PR TITLE
Add LoL client path support

### DIFF
--- a/api.go
+++ b/api.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"os/exec"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -122,6 +123,30 @@ func (api Api) GetLcuAuthInfo(c *gin.Context) {
 		"token": token,
 		"port":  port,
 	})
+}
+
+func (api Api) GetClientPath(c *gin.Context) {
+	app := ginApp.GetApp(c)
+	path, err := lcu.FindLolPath()
+	if err != nil {
+		app.CommonError(err)
+		return
+	}
+	app.Data(gin.H{"path": path})
+}
+
+func (api Api) StartClient(c *gin.Context) {
+	app := ginApp.GetApp(c)
+	path, err := lcu.FindLolPath()
+	if err != nil {
+		app.CommonError(err)
+		return
+	}
+	if err = exec.Command(path).Start(); err != nil {
+		app.CommonError(err)
+		return
+	}
+	app.Success()
 }
 func (api Api) LcuProxy(c *gin.Context) {
 	app := ginApp.GetApp(c)

--- a/frontend/bindings/Soraka/service/lcu/wailsapi.ts
+++ b/frontend/bindings/Soraka/service/lcu/wailsapi.ts
@@ -9,7 +9,7 @@
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Unused imports
-import {Call as $Call, Create as $Create} from "@wailsio/runtime";
+import { Call as $Call, Create as $Create } from "@wailsio/runtime";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Unused imports
@@ -19,40 +19,50 @@ import * as $models from "./models.js";
  * GetAuthInfo retrieves the LCU authentication information.
  */
 export function GetAuthInfo(): Promise<$models.AuthInfo> & { cancel(): void } {
-    let $resultPromise = $Call.ByID(3527704851) as any;
-    let $typingPromise = $resultPromise.then(($result: any) => {
-        return $$createType0($result);
-    }) as any;
-    $typingPromise.cancel = $resultPromise.cancel.bind($resultPromise);
-    return $typingPromise;
+  let $resultPromise = $Call.ByID(3527704851) as any;
+  let $typingPromise = $resultPromise.then(($result: any) => {
+    return $$createType0($result);
+  }) as any;
+  $typingPromise.cancel = $resultPromise.cancel.bind($resultPromise);
+  return $typingPromise;
 }
 
 /**
  * GetCurrentSummoner returns basic info about the current summoner.
  */
-export function GetCurrentSummoner(): Promise<$models.SummonerInfo> & { cancel(): void } {
-    let $resultPromise = $Call.ByID(1692215426) as any;
-    let $typingPromise = $resultPromise.then(($result: any) => {
-        return $$createType1($result);
-    }) as any;
-    $typingPromise.cancel = $resultPromise.cancel.bind($resultPromise);
-    return $typingPromise;
+export function GetCurrentSummoner(): Promise<$models.SummonerInfo> & {
+  cancel(): void;
+} {
+  let $resultPromise = $Call.ByID(1692215426) as any;
+  let $typingPromise = $resultPromise.then(($result: any) => {
+    return $$createType1($result);
+  }) as any;
+  $typingPromise.cancel = $resultPromise.cancel.bind($resultPromise);
+  return $typingPromise;
 }
 
 /**
  * Must implement Name() to satisfy application.Service interface
  */
 export function Name(): Promise<string> & { cancel(): void } {
-    let $resultPromise = $Call.ByID(490243160) as any;
-    return $resultPromise;
+  let $resultPromise = $Call.ByID(490243160) as any;
+  return $resultPromise;
 }
 
 /**
  * StartClient attempts to start the League client if required.
  */
 export function StartClient(): Promise<void> & { cancel(): void } {
-    let $resultPromise = $Call.ByID(1731175274) as any;
-    return $resultPromise;
+  let $resultPromise = $Call.ByID(1731175274) as any;
+  return $resultPromise;
+}
+
+/**
+ * GetClientPath returns the League of Legends executable path.
+ */
+export function GetClientPath(): Promise<string> & { cancel(): void } {
+  let $resultPromise = $Call.ByID(329842285) as any;
+  return $resultPromise;
 }
 
 // Private type creation functions

--- a/frontend/bindings/Soraka/service/lcu/wailsapi.ts
+++ b/frontend/bindings/Soraka/service/lcu/wailsapi.ts
@@ -9,7 +9,7 @@
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Unused imports
-import { Call as $Call, Create as $Create } from "@wailsio/runtime";
+import {Call as $Call, Create as $Create} from "@wailsio/runtime";
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Unused imports
@@ -19,50 +19,48 @@ import * as $models from "./models.js";
  * GetAuthInfo retrieves the LCU authentication information.
  */
 export function GetAuthInfo(): Promise<$models.AuthInfo> & { cancel(): void } {
-  let $resultPromise = $Call.ByID(3527704851) as any;
-  let $typingPromise = $resultPromise.then(($result: any) => {
-    return $$createType0($result);
-  }) as any;
-  $typingPromise.cancel = $resultPromise.cancel.bind($resultPromise);
-  return $typingPromise;
-}
-
-/**
- * GetCurrentSummoner returns basic info about the current summoner.
- */
-export function GetCurrentSummoner(): Promise<$models.SummonerInfo> & {
-  cancel(): void;
-} {
-  let $resultPromise = $Call.ByID(1692215426) as any;
-  let $typingPromise = $resultPromise.then(($result: any) => {
-    return $$createType1($result);
-  }) as any;
-  $typingPromise.cancel = $resultPromise.cancel.bind($resultPromise);
-  return $typingPromise;
-}
-
-/**
- * Must implement Name() to satisfy application.Service interface
- */
-export function Name(): Promise<string> & { cancel(): void } {
-  let $resultPromise = $Call.ByID(490243160) as any;
-  return $resultPromise;
-}
-
-/**
- * StartClient attempts to start the League client if required.
- */
-export function StartClient(): Promise<void> & { cancel(): void } {
-  let $resultPromise = $Call.ByID(1731175274) as any;
-  return $resultPromise;
+    let $resultPromise = $Call.ByID(3527704851) as any;
+    let $typingPromise = $resultPromise.then(($result: any) => {
+        return $$createType0($result);
+    }) as any;
+    $typingPromise.cancel = $resultPromise.cancel.bind($resultPromise);
+    return $typingPromise;
 }
 
 /**
  * GetClientPath returns the League of Legends executable path.
  */
 export function GetClientPath(): Promise<string> & { cancel(): void } {
-  let $resultPromise = $Call.ByID(329842285) as any;
-  return $resultPromise;
+    let $resultPromise = $Call.ByID(329842285) as any;
+    return $resultPromise;
+}
+
+/**
+ * GetCurrentSummoner returns basic info about the current summoner.
+ */
+export function GetCurrentSummoner(): Promise<$models.SummonerInfo> & { cancel(): void } {
+    let $resultPromise = $Call.ByID(1692215426) as any;
+    let $typingPromise = $resultPromise.then(($result: any) => {
+        return $$createType1($result);
+    }) as any;
+    $typingPromise.cancel = $resultPromise.cancel.bind($resultPromise);
+    return $typingPromise;
+}
+
+/**
+ * Must implement Name() to satisfy application.Service interface
+ */
+export function Name(): Promise<string> & { cancel(): void } {
+    let $resultPromise = $Call.ByID(490243160) as any;
+    return $resultPromise;
+}
+
+/**
+ * StartClient attempts to start the League client if required.
+ */
+export function StartClient(): Promise<void> & { cancel(): void } {
+    let $resultPromise = $Call.ByID(1731175274) as any;
+    return $resultPromise;
 }
 
 // Private type creation functions

--- a/frontend/src/views/home/components/Welcome.vue
+++ b/frontend/src/views/home/components/Welcome.vue
@@ -49,14 +49,16 @@ const authInfo = ref<AuthInfo | null>(null);
 
 onMounted(() => {
   // 初始化获取 LCU 凭证
-  WailsAPI.GetAuthInfo().then((info: AuthInfo) => {
-    authInfo.value = info
-    lcuOnline.value = true
-    lcuPort.value = String(info.port)
-    lcuToken.value = info.token
-  }).catch(() => {
-    lcuOnline.value = false
-  })
+  WailsAPI.GetAuthInfo()
+    .then((info: AuthInfo) => {
+      authInfo.value = info;
+      lcuOnline.value = true;
+      lcuPort.value = String(info.port);
+      lcuToken.value = info.token;
+    })
+    .catch(() => {
+      lcuOnline.value = false;
+    });
 
   // 获取当前召唤师信息
   WailsAPI.GetCurrentSummoner().then((info: any) => {
@@ -64,10 +66,10 @@ onMounted(() => {
       userStore.setInfo({
         nickname: info.displayName,
         avatar: `https://127.0.0.1:${authInfo.value.port}/lol-game-data/assets/v1/profile-icons/${info.profileIconId}.jpg`,
-        region: info.region
-      })
+        region: info.region,
+      });
     }
-  })
+  });
 
   // 监听系统时间事件
   Events.On("time", (time: any) => {
@@ -75,42 +77,47 @@ onMounted(() => {
     sysTime.value = time.data as string;
   });
 
-  // 监听 clientPath 事件
-  Events.On("clientPath", (p: any) => {
-    console.log("[Event] clientPath 收到:", p);
-    clientPath.value = p.data as string;
-  });
+  // 获取客户端路径
+  WailsAPI.GetClientPath()
+    .then((p: string) => {
+      clientPath.value = p;
+    })
+    .catch(() => {
+      clientPath.value = "";
+    });
 
   // 监听 lcuStatus 事件
   Events.On("lcuStatus", (d: any) => {
     console.log("[Event] lcuStatus 收到:", d);
     const status = Array.isArray(d.data) ? d.data[0] : d.data;
-    if (typeof status === 'boolean') {
+    if (typeof status === "boolean") {
       lcuOnline.value = status;
     } else {
       console.warn("[Event] lcuStatus 数据格式异常:", d.data);
-      lcuOnline.value = false;  // 或保留上次值
+      lcuOnline.value = false; // 或保留上次值
     }
     console.log("[状态] 更新 lcuOnline:", lcuOnline.value);
   });
-
 
   // 监听 lcuCreds 事件
   Events.On("lcuCreds", (d: any) => {
     console.log("[Event] lcuCreds 收到:", d);
     const creds = Array.isArray(d.data) ? d.data[0] : d.data;
-    if (creds && typeof creds === 'object') {
+    if (creds && typeof creds === "object") {
       lcuPort.value = creds.port ?? "";
       lcuToken.value = creds.token ?? "";
-      console.log("[状态] 更新 lcuPort:", lcuPort.value, "lcuToken:", lcuToken.value);
+      console.log(
+        "[状态] 更新 lcuPort:",
+        lcuPort.value,
+        "lcuToken:",
+        lcuToken.value,
+      );
     } else {
       console.warn("[Event] lcuCreds 数据格式异常:", d.data);
       lcuPort.value = "";
       lcuToken.value = "";
     }
   });
-
-
 });
 </script>
 

--- a/frontend/src/views/home/components/quick-operation.vue
+++ b/frontend/src/views/home/components/quick-operation.vue
@@ -5,38 +5,43 @@
     :header-style="{ paddingBottom: '0' }"
     :body-style="{ padding: '24px 20px 0 20px' }"
   >
-<!--    <template #extra>-->
-<!--      <a-link>管理</a-link>-->
-<!--    </template>-->
+    <!--    <template #extra>-->
+    <!--      <a-link>管理</a-link>-->
+    <!--    </template>-->
     <a-row :gutter="8">
-      <template v-for="link in links" >
-        <a-col :span="8" v-if="link.type=='button'" class="wrapper" @click="handleOpen(link.value)">
+      <template v-for="link in links">
+        <a-col
+          :span="8"
+          v-if="link.type == 'button'"
+          class="wrapper"
+          @click="handleOpen(link.value)"
+        >
           <div class="icon">
-            <icon-font :type="link.icon" class="icon" size="26"/>
+            <icon-font :type="link.icon" class="icon" size="26" />
           </div>
           <a-typography-paragraph class="text">
             {{ link.text }}
           </a-typography-paragraph>
         </a-col>
-<!--        <a-col :span="8" v-else-if="link.type=='browser'" class="wrapper">-->
-<!--            <a :wml-openURL="link.value">-->
-<!--              <div class="icon">-->
-<!--                <icon-font :type="link.icon" class="icon" size="26"/>-->
-<!--              </div>-->
-<!--              <a-typography-paragraph class="text">-->
-<!--                {{ link.text }}-->
-<!--              </a-typography-paragraph>-->
-<!--            </a>-->
-<!--        </a-col>-->
-        <a-col :span="8" v-else-if="link.type=='a'" class="wrapper">
-            <a :href="link.value"  target="_blank">
-              <div class="icon">
-                <icon-font :type="link.icon" class="icon" size="26"/>
-              </div>
-              <a-typography-paragraph class="text">
-                {{ link.text }}
-              </a-typography-paragraph>
-            </a>
+        <!--        <a-col :span="8" v-else-if="link.type=='browser'" class="wrapper">-->
+        <!--            <a :wml-openURL="link.value">-->
+        <!--              <div class="icon">-->
+        <!--                <icon-font :type="link.icon" class="icon" size="26"/>-->
+        <!--              </div>-->
+        <!--              <a-typography-paragraph class="text">-->
+        <!--                {{ link.text }}-->
+        <!--              </a-typography-paragraph>-->
+        <!--            </a>-->
+        <!--        </a-col>-->
+        <a-col :span="8" v-else-if="link.type == 'a'" class="wrapper">
+          <a :href="link.value" target="_blank">
+            <div class="icon">
+              <icon-font :type="link.icon" class="icon" size="26" />
+            </div>
+            <a-typography-paragraph class="text">
+              {{ link.text }}
+            </a-typography-paragraph>
+          </a>
         </a-col>
       </template>
     </a-row>
@@ -45,51 +50,69 @@
 </template>
 
 <script lang="ts" setup>
-import {onMounted } from 'vue';
-import { Notification, Message } from '@arco-design/web-vue';
-import {WML} from "@wailsio/runtime";
+import { onMounted } from "vue";
+import { Notification, Message } from "@arco-design/web-vue";
+import { WML } from "@wailsio/runtime";
 import { WailsAPI } from "/#/Soraka/service/lcu";
-onMounted(async()=>{
-    WML.Reload()
-})
-  const links = [
-    // { text: '通知提醒框', icon: 'icon-filled',type:"button",value:"notification" },
-    // { text: '默认浏览器', icon: 'icon-wangye',type:"browser",value:"https://Sorakas.cn"},
-    // { text: 'Webview', icon: 'icon-wangye',type:"a",value:"https://v3alpha.wails.io"},
-    { text: '启动LOL', icon: 'icon-Game',type:"button",value:"startclient"},
-    // { text: 'workplace.onlinePromotion', icon: 'icon-mobile' },
-    // { text: 'workplace.contentPutIn', icon: 'icon-fire' },
-  ];
-  //执行UI组件
-  const handleOpen=(val:string)=>{
-    if(val=="notification"){
-        Notification.info({
-          title: 'Notification',
-          content: 'This is a notification!',
-          position: 'bottomRight',
-          closable: true,
-        })
-    } else if(val=="startclient") {
-        Message.loading({content:'启动中，请稍后', id:'startclient', duration:0})
-        WailsAPI.StartClient().then(() => {
-            Message.success({content:'启动成功', id:'startclient', duration:2000})
-        }).catch((e:any)=>{
-            Notification.error({title:'启动失败',content:String(e),position:'bottomRight'})
-            Message.error({content:'启动失败', id:'startclient', duration:2000})
-        })
-    }
+onMounted(async () => {
+  WML.Reload();
+});
+const links = [
+  // { text: '通知提醒框', icon: 'icon-filled',type:"button",value:"notification" },
+  // { text: '默认浏览器', icon: 'icon-wangye',type:"browser",value:"https://Sorakas.cn"},
+  // { text: 'Webview', icon: 'icon-wangye',type:"a",value:"https://v3alpha.wails.io"},
+  { text: "启动LOL", icon: "icon-Game", type: "button", value: "startclient" },
+  // { text: 'workplace.onlinePromotion', icon: 'icon-mobile' },
+  // { text: 'workplace.contentPutIn', icon: 'icon-fire' },
+];
+//执行UI组件
+const handleOpen = (val: string) => {
+  if (val == "notification") {
+    Notification.info({
+      title: "Notification",
+      content: "This is a notification!",
+      position: "bottomRight",
+      closable: true,
+    });
+  } else if (val == "startclient") {
+    Message.loading({
+      content: "启动中，请稍后",
+      id: "startclient",
+      duration: 0,
+    });
+    WailsAPI.StartClient()
+      .then(() => {
+        Message.success({
+          content: "启动成功",
+          id: "startclient",
+          duration: 2000,
+        });
+      })
+      .catch((e: any) => {
+        Notification.error({
+          title: "启动失败",
+          content: String(e),
+          position: "bottomRight",
+        });
+        Message.error({
+          content: "启动失败",
+          id: "startclient",
+          duration: 2000,
+        });
+      });
   }
+};
 </script>
 
 <style scoped lang="less">
-.general-card{
+.general-card {
   background: transparent;
-  .wrapper{
+  .wrapper {
     cursor: pointer;
-    .icon{
+    .icon {
       text-align: center;
     }
-    .text{
+    .text {
       text-align: center;
     }
   }

--- a/routes.go
+++ b/routes.go
@@ -19,6 +19,8 @@ func initV1Module(r *gin.Engine, api *Api) {
 	v1.POST("config/update", api.UpdateClientConf)
 	// 获取lcu认证信息
 	v1.POST("lcu/getAuthInfo", api.GetLcuAuthInfo)
+	v1.POST("game/getPath", api.GetClientPath)
+	v1.POST("game/start", api.StartClient)
 	// 获取app信息
 	v1.POST("app/getInfo", api.GetAppInfo)
 	// 复制马匹信息到剪切板

--- a/service/lcu/client_path.go
+++ b/service/lcu/client_path.go
@@ -1,0 +1,6 @@
+package lcu
+
+// Stub for non-windows builds
+func FindLolPath() (string, error) {
+	return "", ErrLolProcessNotFound
+}

--- a/service/lcu/client_path.go
+++ b/service/lcu/client_path.go
@@ -1,6 +1,6 @@
 package lcu
 
 // Stub for non-windows builds
-func FindLolPath() (string, error) {
-	return "", ErrLolProcessNotFound
-}
+//func FindLolPath() (string, error) {
+//	return "", ErrLolProcessNotFound
+//}

--- a/service/lcu/client_path_windows.go
+++ b/service/lcu/client_path_windows.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package lcu
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+// FindLolPath attempts to locate the League of Legends executable path from the Windows registry.
+func FindLolPath() (string, error) {
+	roots := []registry.Key{registry.LOCAL_MACHINE, registry.CURRENT_USER}
+	subkeys := []string{
+		`SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`,
+		`SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall`,
+	}
+	for _, r := range roots {
+		for _, sub := range subkeys {
+			k, err := registry.OpenKey(r, sub, registry.READ)
+			if err != nil {
+				continue
+			}
+			names, err := k.ReadSubKeyNames(-1)
+			if err != nil {
+				k.Close()
+				continue
+			}
+			for _, name := range names {
+				sk, err := registry.OpenKey(k, name, registry.READ)
+				if err != nil {
+					continue
+				}
+				display, _, _ := sk.GetStringValue("DisplayName")
+				if strings.Contains(display, "英雄联盟") || strings.Contains(display, "League of Legends") {
+					if loc, _, err := sk.GetStringValue("InstallLocation"); err == nil && loc != "" {
+						sk.Close()
+						k.Close()
+						return filepath.Join(loc, "League of Legends.exe"), nil
+					}
+					if icon, _, err := sk.GetStringValue("DisplayIcon"); err == nil && icon != "" {
+						sk.Close()
+						k.Close()
+						return icon, nil
+					}
+				}
+				sk.Close()
+			}
+			k.Close()
+		}
+	}
+	return "", errors.New("LOL path not found in registry")
+}

--- a/service/lcu/wailsapi.go
+++ b/service/lcu/wailsapi.go
@@ -1,7 +1,10 @@
 package lcu
 
 import (
+	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 // WailsAPI exposes methods for the frontend via Wails service
@@ -52,10 +55,24 @@ func (WailsAPI) GetCurrentSummoner() (SummonerInfo, error) {
 
 // StartClient attempts to start the League client if required.
 func (WailsAPI) StartClient() error {
-	path, err := FindLolPath()
+	base, err := FindLolPath()
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command(path)
-	return cmd.Start()
+
+	// 常见的 LOL 客户端主程序名称
+	executables := []string{
+		"LeagueClient.exe",
+		"client.exe",
+	}
+
+	for _, exe := range executables {
+		fullPath := filepath.Join(base, exe)
+		if _, err := os.Stat(fullPath); err == nil {
+			cmd := exec.Command(fullPath)
+			return cmd.Start()
+		}
+	}
+
+	return fmt.Errorf("no executable client found in: %s", base)
 }

--- a/service/lcu/wailsapi.go
+++ b/service/lcu/wailsapi.go
@@ -1,5 +1,9 @@
 package lcu
 
+import (
+	"os/exec"
+)
+
 // WailsAPI exposes methods for the frontend via Wails service
 // to interact with the local League client.
 type WailsAPI struct{}
@@ -16,6 +20,11 @@ type SummonerInfo struct {
 	DisplayName   string `json:"displayName"`
 	ProfileIconId int    `json:"profileIconId"`
 	Region        string `json:"region"`
+}
+
+// GetClientPath returns the League of Legends executable path.
+func (WailsAPI) GetClientPath() (string, error) {
+	return FindLolPath()
 }
 
 // GetAuthInfo retrieves the LCU authentication information.
@@ -43,6 +52,10 @@ func (WailsAPI) GetCurrentSummoner() (SummonerInfo, error) {
 
 // StartClient attempts to start the League client if required.
 func (WailsAPI) StartClient() error {
-	// Add real implementation here if needed
-	return nil
+	path, err := FindLolPath()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(path)
+	return cmd.Start()
 }


### PR DESCRIPTION
## Summary
- expose `GetClientPath` and update `StartClient` in Wails API
- implement Windows registry search for LoL executable
- add HTTP endpoints for getting path and starting the client
- hook up new calls in Welcome and quick-operation pages
- update TypeScript bindings

## Testing
- `npx prettier -w frontend/src/views/home/components/Welcome.vue frontend/src/views/home/components/quick-operation.vue frontend/bindings/Soraka/service/lcu/wailsapi.ts`
- `gofmt -w service/lcu/wailsapi.go service/lcu/client_path.go service/lcu/client_path_windows.go api.go routes.go`
- `go test ./...` *(fails: access to proxy.golang.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6855f31047a8832d8ed889442cd2c716