### PR TITLE
Update welcome connection listeners

### DIFF
--- a/api.go
+++ b/api.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
 	"os/exec"
 	"strings"
 
@@ -149,13 +151,18 @@ func (api Api) StartClient(c *gin.Context) {
 	app.Success()
 }
 func (api Api) LcuProxy(c *gin.Context) {
-	app := ginApp.GetApp(c)
-	path := c.Param("any")
-	c.Request.URL.Path = path
-	rp := api.p.lcuRP
-	if rp == nil {
-		app.ErrorMsg("反向代理未初始化")
+	if api.p == nil {
+		fmt.Println("[错误] api.p 是 nil")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "LCU代理未初始化 [p]"})
 		return
 	}
-	rp.ServeHTTP(c.Writer, c.Request)
+	if api.p.lcuRP == nil {
+		fmt.Println("[错误] api.p.lcuRP 是 nil")
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "LCU代理未初始化 [lcuRP]"})
+		return
+	}
+
+	path := c.Param("any")
+	c.Request.URL.Path = path
+	api.p.lcuRP.ServeHTTP(c.Writer, c.Request)
 }

--- a/dal/lcu/models/api.go
+++ b/dal/lcu/models/api.go
@@ -26,10 +26,12 @@ type (
 	}
 	CurrSummoner struct {
 		AccountId                   int64  `json:"accountId"`
+		GameName                    string `json:"gameName"`
 		DisplayName                 string `json:"displayName"`
 		InternalName                string `json:"internalName"`
 		NameChangeFlag              bool   `json:"nameChangeFlag"`
 		PercentCompleteForNextLevel int    `json:"percentCompleteForNextLevel"`
+		Privacy                     string `json:"privacy"`
 		ProfileIconId               int    `json:"profileIconId"`
 		Puuid                       string `json:"puuid"`
 		RerollPoints                struct {
@@ -40,7 +42,6 @@ type (
 			PointsToReroll   int `json:"pointsToReroll"`
 		} `json:"rerollPoints"`
 		SummonerId       int64  `json:"summonerId"`
-		GameName         string `json:"gameName"`
 		TagLine          string `json:"tagLine"`
 		SummonerLevel    int    `json:"summonerLevel"`
 		Unnamed          bool   `json:"unnamed"`
@@ -741,9 +742,13 @@ type (
 		GameName                string      `json:"gameName"`
 		GameTag                 string      `json:"gameTag"`
 		Icon                    int         `json:"icon"`
-		Id                      string      `json:"id"`
-		LastSeenOnlineTimestamp interface{} `json:"lastSeenOnlineTimestamp"`
+		ID                      string      `json:"id"`
+		LastSeenOnlineTimestamp interface{} `json:"lastSeenOnlineTimestamp"` // 可以是 null
 		Lol                     struct {
+			BannerIdSelected         string `json:"bannerIdSelected"`
+			ChallengeCrystalLevel    string `json:"challengeCrystalLevel"`
+			ChallengePoints          string `json:"challengePoints"`
+			ChallengeTokensSelected  string `json:"challengeTokensSelected"`
 			ChampionId               string `json:"championId"`
 			CompanionId              string `json:"companionId"`
 			DamageSkinId             string `json:"damageSkinId"`
@@ -754,6 +759,7 @@ type (
 			Level                    string `json:"level"`
 			MapId                    string `json:"mapId"`
 			MapSkinId                string `json:"mapSkinId"`
+			PlayerTitleSelected      string `json:"playerTitleSelected"`
 			Puuid                    string `json:"puuid"`
 			RankedLeagueDivision     string `json:"rankedLeagueDivision"`
 			RankedLeagueQueue        string `json:"rankedLeagueQueue"`

--- a/dal/lcu/models/lol.go
+++ b/dal/lcu/models/lol.go
@@ -113,11 +113,52 @@ const (
 	TeamIDStrRed  TeamIDStr = "200" // 红色方
 )
 
-// 大区id
+// 平台大区 ID（用于 profile.PlatformId）
 const (
-	PlatformIDDX1 = "HN1" // 艾欧尼亚
-	PlatformIDDX2 = "HN2" // 祖安
+	PlatformIDHN1  = "HN1"  // 艾欧尼亚
+	PlatformIDHN2  = "HN2"  // 祖安
+	PlatformIDHN3  = "HN3"  // 诺克萨斯
+	PlatformIDHN4  = "HN4"  // 班德尔城
+	PlatformIDHN5  = "HN5"  // 皮尔特沃夫
+	PlatformIDHN6  = "HN6"  // 战争学院
+	PlatformIDHN7  = "HN7"  // 巨神峰
+	PlatformIDHN8  = "HN8"  // 雷瑟守备
+	PlatformIDHN9  = "HN9"  // 裁决之地
+	PlatformIDHN10 = "HN10" // 黑色玫瑰
+	PlatformIDHN11 = "HN11" // 暗影岛
+	PlatformIDHN12 = "HN12" // 钢铁烈阳
+	PlatformIDHN13 = "HN13" // 水晶之痕
+	PlatformIDHN14 = "HN14" // 均衡教派
+	PlatformIDHN15 = "HN15" // 影流
+	PlatformIDHN16 = "HN16" // 守望之海
+	PlatformIDHN17 = "HN17" // 征服之海
+	PlatformIDHN18 = "HN18" // 卡拉曼达
+	PlatformIDHN19 = "HN19" // 皮城警备
+	PlatformIDHN20 = "HN20" // 巨龙之巢
 )
+
+var PlatformMap = map[string]string{
+	PlatformIDHN1:  "艾欧尼亚",
+	PlatformIDHN2:  "祖安",
+	PlatformIDHN3:  "诺克萨斯",
+	PlatformIDHN4:  "班德尔城",
+	PlatformIDHN5:  "皮尔特沃夫",
+	PlatformIDHN6:  "战争学院",
+	PlatformIDHN7:  "巨神峰",
+	PlatformIDHN8:  "雷瑟守备",
+	PlatformIDHN9:  "裁决之地",
+	PlatformIDHN10: "黑色玫瑰",
+	PlatformIDHN11: "暗影岛",
+	PlatformIDHN12: "钢铁烈阳",
+	PlatformIDHN13: "水晶之痕",
+	PlatformIDHN14: "均衡教派",
+	PlatformIDHN15: "影流",
+	PlatformIDHN16: "守望之海",
+	PlatformIDHN17: "征服之海",
+	PlatformIDHN18: "卡拉曼达",
+	PlatformIDHN19: "皮城警备",
+	PlatformIDHN20: "巨龙之巢",
+}
 
 // 召唤师技能
 const (

--- a/frontend/bindings/Soraka/service/lcu/models.ts
+++ b/frontend/bindings/Soraka/service/lcu/models.ts
@@ -3,58 +3,104 @@
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Unused imports
-import {Create as $Create} from "@wailsio/runtime";
+import { Create as $Create } from "@wailsio/runtime";
 
 export class AuthInfo {
-    "port": number;
-    "token": string;
+  "port": number;
+  "token": string;
 
-    /** Creates a new AuthInfo instance. */
-    constructor($$source: Partial<AuthInfo> = {}) {
-        if (!("port" in $$source)) {
-            this["port"] = 0;
-        }
-        if (!("token" in $$source)) {
-            this["token"] = "";
-        }
-
-        Object.assign(this, $$source);
+  /** Creates a new AuthInfo instance. */
+  constructor($$source: Partial<AuthInfo> = {}) {
+    if (!("port" in $$source)) {
+      this["port"] = 0;
+    }
+    if (!("token" in $$source)) {
+      this["token"] = "";
     }
 
-    /**
-     * Creates a new AuthInfo instance from a string or object.
-     */
-    static createFrom($$source: any = {}): AuthInfo {
-        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
-        return new AuthInfo($$parsedSource as Partial<AuthInfo>);
-    }
+    Object.assign(this, $$source);
+  }
+
+  /**
+   * Creates a new AuthInfo instance from a string or object.
+   */
+  static createFrom($$source: any = {}): AuthInfo {
+    let $$parsedSource =
+      typeof $$source === "string" ? JSON.parse($$source) : $$source;
+    return new AuthInfo($$parsedSource as Partial<AuthInfo>);
+  }
 }
 
 export class SummonerInfo {
-    "displayName": string;
-    "profileIconId": number;
-    "region": string;
+  "displayName": string;
+  "profileIconId": number;
+  "region": string;
+  "avatar": string;
+  "tag": string;
+  "rank": string;
+  "winRate": number;
+  "wins": number;
+  "losses": number;
+  "totalGames": number;
+  "createtime": string;
+  "level": number;
+  "xpSinceLastLevel": number;
+  "xpUntilNextLevel": number;
 
-    /** Creates a new SummonerInfo instance. */
-    constructor($$source: Partial<SummonerInfo> = {}) {
-        if (!("displayName" in $$source)) {
-            this["displayName"] = "";
-        }
-        if (!("profileIconId" in $$source)) {
-            this["profileIconId"] = 0;
-        }
-        if (!("region" in $$source)) {
-            this["region"] = "";
-        }
-
-        Object.assign(this, $$source);
+  /** Creates a new SummonerInfo instance. */
+  constructor($$source: Partial<SummonerInfo> = {}) {
+    if (!("displayName" in $$source)) {
+      this["displayName"] = "";
+    }
+    if (!("profileIconId" in $$source)) {
+      this["profileIconId"] = 0;
+    }
+    if (!("region" in $$source)) {
+      this["region"] = "";
+    }
+    if (!("avatar" in $$source)) {
+      this["avatar"] = "";
+    }
+    if (!("tag" in $$source)) {
+      this["tag"] = "";
+    }
+    if (!("rank" in $$source)) {
+      this["rank"] = "";
+    }
+    if (!("winRate" in $$source)) {
+      this["winRate"] = 0;
+    }
+    if (!("wins" in $$source)) {
+      this["wins"] = 0;
+    }
+    if (!("losses" in $$source)) {
+      this["losses"] = 0;
+    }
+    if (!("totalGames" in $$source)) {
+      this["totalGames"] = 0;
+    }
+    if (!("createtime" in $$source)) {
+      this["createtime"] = "";
+    }
+    if (!("level" in $$source)) {
+      this["level"] = 0;
+    }
+    if (!("xpSinceLastLevel" in $$source)) {
+      this["xpSinceLastLevel"] = 0;
+    }
+    if (!("xpUntilNextLevel" in $$source)) {
+      this["xpUntilNextLevel"] = 0;
     }
 
-    /**
-     * Creates a new SummonerInfo instance from a string or object.
-     */
-    static createFrom($$source: any = {}): SummonerInfo {
-        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
-        return new SummonerInfo($$parsedSource as Partial<SummonerInfo>);
-    }
+    Object.assign(this, $$source);
+  }
+
+  /**
+   * Creates a new SummonerInfo instance from a string or object.
+   */
+  static createFrom($$source: any = {}): SummonerInfo {
+    let $$parsedSource =
+      typeof $$source === "string" ? JSON.parse($$source) : $$source;
+    return new SummonerInfo($$parsedSource as Partial<SummonerInfo>);
+  }
 }

--- a/frontend/bindings/Soraka/service/lcu/models.ts
+++ b/frontend/bindings/Soraka/service/lcu/models.ts
@@ -3,104 +3,106 @@
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: Unused imports
-import { Create as $Create } from "@wailsio/runtime";
+import {Create as $Create} from "@wailsio/runtime";
 
 export class AuthInfo {
-  "port": number;
-  "token": string;
+    "port": number;
+    "token": string;
 
-  /** Creates a new AuthInfo instance. */
-  constructor($$source: Partial<AuthInfo> = {}) {
-    if (!("port" in $$source)) {
-      this["port"] = 0;
+    /** Creates a new AuthInfo instance. */
+    constructor($$source: Partial<AuthInfo> = {}) {
+        if (!("port" in $$source)) {
+            this["port"] = 0;
+        }
+        if (!("token" in $$source)) {
+            this["token"] = "";
+        }
+
+        Object.assign(this, $$source);
     }
-    if (!("token" in $$source)) {
-      this["token"] = "";
+
+    /**
+     * Creates a new AuthInfo instance from a string or object.
+     */
+    static createFrom($$source: any = {}): AuthInfo {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new AuthInfo($$parsedSource as Partial<AuthInfo>);
     }
-
-    Object.assign(this, $$source);
-  }
-
-  /**
-   * Creates a new AuthInfo instance from a string or object.
-   */
-  static createFrom($$source: any = {}): AuthInfo {
-    let $$parsedSource =
-      typeof $$source === "string" ? JSON.parse($$source) : $$source;
-    return new AuthInfo($$parsedSource as Partial<AuthInfo>);
-  }
 }
 
 export class SummonerInfo {
-  "displayName": string;
-  "profileIconId": number;
-  "region": string;
-  "avatar": string;
-  "tag": string;
-  "rank": string;
-  "winRate": number;
-  "wins": number;
-  "losses": number;
-  "totalGames": number;
-  "createtime": string;
-  "level": number;
-  "xpSinceLastLevel": number;
-  "xpUntilNextLevel": number;
+    "displayName": string;
+    "profileIconId": number;
+    "region": string;
+    "server": string;
+    "avatar": string;
+    "tag": string;
+    "rank": string;
+    "winRate": number;
+    "wins": number;
+    "losses": number;
+    "totalGames": number;
+    "createtime": string;
+    "level": number;
+    "xpSinceLastLevel": number;
+    "xpUntilNextLevel": number;
 
-  /** Creates a new SummonerInfo instance. */
-  constructor($$source: Partial<SummonerInfo> = {}) {
-    if (!("displayName" in $$source)) {
-      this["displayName"] = "";
-    }
-    if (!("profileIconId" in $$source)) {
-      this["profileIconId"] = 0;
-    }
-    if (!("region" in $$source)) {
-      this["region"] = "";
-    }
-    if (!("avatar" in $$source)) {
-      this["avatar"] = "";
-    }
-    if (!("tag" in $$source)) {
-      this["tag"] = "";
-    }
-    if (!("rank" in $$source)) {
-      this["rank"] = "";
-    }
-    if (!("winRate" in $$source)) {
-      this["winRate"] = 0;
-    }
-    if (!("wins" in $$source)) {
-      this["wins"] = 0;
-    }
-    if (!("losses" in $$source)) {
-      this["losses"] = 0;
-    }
-    if (!("totalGames" in $$source)) {
-      this["totalGames"] = 0;
-    }
-    if (!("createtime" in $$source)) {
-      this["createtime"] = "";
-    }
-    if (!("level" in $$source)) {
-      this["level"] = 0;
-    }
-    if (!("xpSinceLastLevel" in $$source)) {
-      this["xpSinceLastLevel"] = 0;
-    }
-    if (!("xpUntilNextLevel" in $$source)) {
-      this["xpUntilNextLevel"] = 0;
+    /** Creates a new SummonerInfo instance. */
+    constructor($$source: Partial<SummonerInfo> = {}) {
+        if (!("displayName" in $$source)) {
+            this["displayName"] = "";
+        }
+        if (!("profileIconId" in $$source)) {
+            this["profileIconId"] = 0;
+        }
+        if (!("region" in $$source)) {
+            this["region"] = "";
+        }
+        if (!("server" in $$source)) {
+            this["server"] = "";
+        }
+        if (!("avatar" in $$source)) {
+            this["avatar"] = "";
+        }
+        if (!("tag" in $$source)) {
+            this["tag"] = "";
+        }
+        if (!("rank" in $$source)) {
+            this["rank"] = "";
+        }
+        if (!("winRate" in $$source)) {
+            this["winRate"] = 0;
+        }
+        if (!("wins" in $$source)) {
+            this["wins"] = 0;
+        }
+        if (!("losses" in $$source)) {
+            this["losses"] = 0;
+        }
+        if (!("totalGames" in $$source)) {
+            this["totalGames"] = 0;
+        }
+        if (!("createtime" in $$source)) {
+            this["createtime"] = "";
+        }
+        if (!("level" in $$source)) {
+            this["level"] = 0;
+        }
+        if (!("xpSinceLastLevel" in $$source)) {
+            this["xpSinceLastLevel"] = 0;
+        }
+        if (!("xpUntilNextLevel" in $$source)) {
+            this["xpUntilNextLevel"] = 0;
+        }
+
+        Object.assign(this, $$source);
     }
 
-    Object.assign(this, $$source);
-  }
-
-  /**
-   * Creates a new SummonerInfo instance from a string or object.
-   */
-  static createFrom($$source: any = {}): SummonerInfo {
-    let $$parsedSource =
-      typeof $$source === "string" ? JSON.parse($$source) : $$source;
-    return new SummonerInfo($$parsedSource as Partial<SummonerInfo>);
-  }
+    /**
+     * Creates a new SummonerInfo instance from a string or object.
+     */
+    static createFrom($$source: any = {}): SummonerInfo {
+        let $$parsedSource = typeof $$source === 'string' ? JSON.parse($$source) : $$source;
+        return new SummonerInfo($$parsedSource as Partial<SummonerInfo>);
+    }
 }

--- a/frontend/bindings/Soraka/service/lcu/wailsapi.ts
+++ b/frontend/bindings/Soraka/service/lcu/wailsapi.ts
@@ -35,9 +35,6 @@ export function GetClientPath(): Promise<string> & { cancel(): void } {
     return $resultPromise;
 }
 
-/**
- * GetCurrentSummoner returns basic info about the current summoner.
- */
 export function GetCurrentSummoner(): Promise<$models.SummonerInfo> & { cancel(): void } {
     let $resultPromise = $Call.ByID(1692215426) as any;
     let $typingPromise = $resultPromise.then(($result: any) => {

--- a/frontend/src/api/lcu.ts
+++ b/frontend/src/api/lcu.ts
@@ -1,4 +1,4 @@
-import { defHttp } from '@/utils/http';
+import { defHttp } from "@/utils/http";
 
 export interface AuthInfo {
   port: number;
@@ -7,7 +7,7 @@ export interface AuthInfo {
 
 // 获取LCU登录信息
 export function getLcuAuthInfo() {
-  return defHttp.post<AuthInfo>({ url: '/v1/lcu/getAuthInfo' });
+  return defHttp.post<AuthInfo>({ url: "/v1/lcu/getAuthInfo" });
 }
 
 // 通过后端代理获取当前召唤师信息
@@ -15,13 +15,26 @@ export interface SummonerInfo {
   displayName: string;
   profileIconId: number;
   region: string;
+  avatar: string;
+  tag: string;
+  rank: string;
+  winRate: number;
+  wins: number;
+  losses: number;
+  totalGames: number;
+  createtime: string;
+  level: number;
+  xpSinceLastLevel: number;
+  xpUntilNextLevel: number;
 }
 
 export function getCurrentSummoner() {
-  return defHttp.get<SummonerInfo>({ url: '/v1/lcu/proxy/lol-summoner/v1/current-summoner' });
+  return defHttp.get<SummonerInfo>({
+    url: "/v1/lcu/proxy/lol-summoner/v1/current-summoner",
+  });
 }
 
 // 启动LOL客户端
 export function startClient() {
-  return defHttp.post({ url: '/v1/client/start' });
+  return defHttp.post({ url: "/v1/client/start" });
 }

--- a/frontend/src/layouts/AppSider.vue
+++ b/frontend/src/layouts/AppSider.vue
@@ -76,10 +76,20 @@
 
         <!-- 用户信息 -->
         <div class="footer">
-          <a-avatar :size="32" :src="userStore.avatar || '@/assets/logo.png'" />
+          <img
+              :src="userStore.avatar || defaultAvatar"
+              style="width: 32px; height: 32px; border-radius: 50%"
+          />
+
+
           <div class="footer-text" :class="{ hidden: collapsed }">
-            <div class="footer-name">{{ userStore.nickname || "未登录" }}</div>
-            <div class="footer-rank">{{ userStore.region }}</div>
+            <div class="footer-name">
+              {{ userStore.nickname || '未登录' }}
+              <span v-if="userStore.tag" class="tag">{{ userStore.tag }}</span>
+            </div>
+            <div class="footer-rank">
+              <span v-if="userStore.server">{{ userStore.server }}</span>
+            </div>
           </div>
         </div>
       </div>
@@ -112,6 +122,7 @@ const menulist = computed(
   () => routerMap.find((item) => item.path === "/")?.children || [],
 );
 const authInfo = ref<AuthInfo | null>(null);
+const defaultAvatar = new URL('@/assets/logo.png', import.meta.url).href;
 
 watch(
   () => route.name,
@@ -134,32 +145,6 @@ const handleSetting = () => {
 const handleTool = (type: string) => {
   console.log("工具点击", type);
 };
-
-const loadUserInfo = () => {
-  WailsAPI.GetCurrentSummoner()
-    .then((info: any) => {
-      if (!info || !authInfo.value) return;
-      userStore.setInfo({
-        nickname: info.displayName,
-        avatar: info.avatar,
-        region: info.region,
-        tag: info.tag,
-        rank: info.rank,
-        winRate: info.winRate,
-        wins: info.wins,
-        losses: info.losses,
-        totalGames: info.totalGames,
-        createtime: info.createtime,
-        level: info.level,
-        xpSinceLastLevel: info.xpSinceLastLevel,
-        xpUntilNextLevel: info.xpUntilNextLevel,
-      });
-    })
-    .catch((err) => {
-      console.error("[getCurrentSummoner]", err);
-    });
-};
-
 onMounted(() => {
   WailsAPI.GetAuthInfo()
     .then((info: AuthInfo) => {

--- a/frontend/src/layouts/AppSider.vue
+++ b/frontend/src/layouts/AppSider.vue
@@ -1,13 +1,13 @@
 <template>
   <a-layout id="app-layout-sider">
     <a-layout-sider
-        v-model:collapsed="collapsed"
-        :width="220"
-        :collapsed-width="64"
-        collapsible
-        theme="light"
-        class="layout-sider"
-        :class="{ 'collapsed-sider': collapsed }"
+      v-model:collapsed="collapsed"
+      :width="220"
+      :collapsed-width="64"
+      collapsible
+      theme="light"
+      class="layout-sider"
+      :class="{ 'collapsed-sider': collapsed }"
     >
       <div class="sider-menu">
         <!-- 顶部 logo 与标题 -->
@@ -20,38 +20,44 @@
 
         <!-- 主菜单 -->
         <a-menu
-            class="menu-item"
-            theme="light"
-            mode="vertical"
-            :selected-keys="[current]"
-            @menu-item-click="menuHandle"
+          class="menu-item"
+          theme="light"
+          mode="vertical"
+          :selected-keys="[current]"
+          @menu-item-click="menuHandle"
         >
-        <template v-for="menuInfo in menulist" :key="menuInfo.name">
+          <template v-for="menuInfo in menulist" :key="menuInfo.name">
             <a-menu-item v-if="!menuInfo.meta?.hideInMenu" :key="menuInfo.name">
               <div class="menu-item-inner">
                 <icon-font :type="menuInfo.meta.icon" class="menu-icon" />
-                <span class="menu-text" :class="{ hidden: collapsed }">{{ menuInfo.meta.title }}</span>
+                <span class="menu-text" :class="{ hidden: collapsed }">{{
+                  menuInfo.meta.title
+                }}</span>
               </div>
             </a-menu-item>
           </template>
         </a-menu>
 
         <a-menu
-            class="footer-tools"
-            theme="light"
-            mode="vertical"
-            :selected-keys="current === 'setting' ? ['setting'] : []"
+          class="footer-tools"
+          theme="light"
+          mode="vertical"
+          :selected-keys="current === 'setting' ? ['setting'] : []"
         >
-        <a-menu-item key="opgg" @click="handleTool('opgg')">
+          <a-menu-item key="opgg" @click="handleTool('opgg')">
             <div class="menu-item-inner">
               <img src="@/assets/images/opgg.svg" class="menu-icon" />
-              <span class="menu-text" :class="{ hidden: collapsed }">OP.GG</span>
+              <span class="menu-text" :class="{ hidden: collapsed }"
+                >OP.GG</span
+              >
             </div>
           </a-menu-item>
           <a-menu-item key="fix" @click="handleTool('fix')">
             <div class="menu-item-inner">
               <icon-font type="icon-ArrowCircle" class="menu-icon" />
-              <span class="menu-text" :class="{ hidden: collapsed }">修复无限加载</span>
+              <span class="menu-text" :class="{ hidden: collapsed }"
+                >修复无限加载</span
+              >
             </div>
           </a-menu-item>
           <a-menu-item key="notice" @click="handleTool('notice')">
@@ -72,7 +78,7 @@
         <div class="footer">
           <a-avatar :size="32" :src="userStore.avatar || '@/assets/logo.png'" />
           <div class="footer-text" :class="{ hidden: collapsed }">
-            <div class="footer-name">{{ userStore.nickname || '未登录' }}</div>
+            <div class="footer-name">{{ userStore.nickname || "未登录" }}</div>
             <div class="footer-rank">{{ userStore.region }}</div>
           </div>
         </div>
@@ -88,73 +94,91 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, watch, onMounted } from 'vue'
-import { useRouter, useRoute } from 'vue-router'
-import routerMap from '@/router/routerMap'
-import { Events } from '@wailsio/runtime'
-import type { AuthInfo } from '@/api/lcu'
+import { ref, computed, watch, onMounted } from "vue";
+import { useRouter, useRoute } from "vue-router";
+import routerMap from "@/router/routerMap";
+import { Events } from "@wailsio/runtime";
+import type { AuthInfo } from "@/api/lcu";
 import { WailsAPI } from "/#/Soraka/service/lcu";
-import { useUserStore } from '@/store'
+import { useUserStore } from "@/store";
 
-const router = useRouter()
-const route = useRoute()
-const current = ref(route.name)
-const collapsed = ref(false)
-const userStore = useUserStore()
+const router = useRouter();
+const route = useRoute();
+const current = ref(route.name);
+const collapsed = ref(false);
+const userStore = useUserStore();
 
-const menulist = computed(() => routerMap.find(item => item.path === '/')?.children || [])
-const authInfo = ref<AuthInfo | null>(null)
+const menulist = computed(
+  () => routerMap.find((item) => item.path === "/")?.children || [],
+);
+const authInfo = ref<AuthInfo | null>(null);
 
-watch(() => route.name, name => (current.value = name))
+watch(
+  () => route.name,
+  (name) => (current.value = name),
+);
 
 const menuHandle = (key: string) => {
-  current.value = key
-  const target = menulist.value.find(i => i.name === key)
+  current.value = key;
+  const target = menulist.value.find((i) => i.name === key);
   if (target) {
-    router.push({ name: target.name })
+    router.push({ name: target.name });
   }
-}
-
+};
 
 const handleSetting = () => {
-  current.value = 'setting'
-  router.push({ name: 'setting' })
-}
+  current.value = "setting";
+  router.push({ name: "setting" });
+};
 
-const handleTool = (type :string)=> {
-  console.log('工具点击', type)
-}
+const handleTool = (type: string) => {
+  console.log("工具点击", type);
+};
 
 const loadUserInfo = () => {
-  WailsAPI.GetCurrentSummoner().then((info: any) => {
-    if (!info || !authInfo.value) return
-    userStore.setInfo({
-      nickname: info.displayName,
-      avatar: `https://127.0.0.1:${authInfo.value.port}/lol-game-data/assets/v1/profile-icons/${info.profileIconId}.jpg`,
-      region: info.region
+  WailsAPI.GetCurrentSummoner()
+    .then((info: any) => {
+      if (!info || !authInfo.value) return;
+      userStore.setInfo({
+        nickname: info.displayName,
+        avatar: info.avatar,
+        region: info.region,
+        tag: info.tag,
+        rank: info.rank,
+        winRate: info.winRate,
+        wins: info.wins,
+        losses: info.losses,
+        totalGames: info.totalGames,
+        createtime: info.createtime,
+        level: info.level,
+        xpSinceLastLevel: info.xpSinceLastLevel,
+        xpUntilNextLevel: info.xpUntilNextLevel,
+      });
     })
-  }).catch(err => {
-    console.error('[getCurrentSummoner]', err)
-  })
-}
+    .catch((err) => {
+      console.error("[getCurrentSummoner]", err);
+    });
+};
 
 onMounted(() => {
-  WailsAPI.GetAuthInfo().then((info: AuthInfo) => {
-    authInfo.value = info
-    loadUserInfo()
-  }).catch(() => {
-    console.error('failed to get auth info')
-  })
-  Events.On('lcuStatus', (d: any) => {
-    const status = Array.isArray(d.data) ? d.data[0] : d.data
+  WailsAPI.GetAuthInfo()
+    .then((info: AuthInfo) => {
+      authInfo.value = info;
+      loadUserInfo();
+    })
+    .catch(() => {
+      console.error("failed to get auth info");
+    });
+  Events.On("lcuStatus", (d: any) => {
+    const status = Array.isArray(d.data) ? d.data[0] : d.data;
     if (status) {
       WailsAPI.GetAuthInfo().then((info: AuthInfo) => {
-        authInfo.value = info
-        loadUserInfo()
-      })
+        authInfo.value = info;
+        loadUserInfo();
+      });
     }
-  })
-})
+  });
+});
 </script>
 
 <style scoped lang="less">
@@ -195,7 +219,9 @@ onMounted(() => {
         font-weight: bold;
         margin-left: 12px;
         color: var(--color-text);
-        transition: opacity 0.3s, width 0.3s;
+        transition:
+          opacity 0.3s,
+          width 0.3s;
         white-space: nowrap;
       }
 
@@ -242,7 +268,9 @@ onMounted(() => {
           .menu-text {
             font-size: 14px;
             margin-left: 12px;
-            transition: opacity 0.3s, width 0.3s;
+            transition:
+              opacity 0.3s,
+              width 0.3s;
             white-space: nowrap;
             color: var(--color-text);
           }
@@ -300,7 +328,9 @@ onMounted(() => {
           .menu-text {
             font-size: 14px;
             margin-left: 12px;
-            transition: opacity 0.3s, width 0.3s;
+            transition:
+              opacity 0.3s,
+              width 0.3s;
             white-space: nowrap;
             color: var(--color-text);
           }
@@ -345,7 +375,9 @@ onMounted(() => {
 
       .footer-text {
         margin-left: 12px;
-        transition: opacity 0.3s, width 0.3s;
+        transition:
+          opacity 0.3s,
+          width 0.3s;
         white-space: nowrap;
 
         .footer-name {
@@ -438,7 +470,4 @@ onMounted(() => {
     }
   }
 }
-
-
-
 </style>

--- a/frontend/src/store/modules/user/index.ts
+++ b/frontend/src/store/modules/user/index.ts
@@ -1,73 +1,76 @@
-import { defineStore } from 'pinia'
-import { setToken, getToken, clearToken } from '@/utils/auth'
+import { defineStore } from "pinia";
+import { setToken, getToken, clearToken } from "@/utils/auth";
 
 export interface UserState {
-    nickname?: string
-    avatar?: string
-    region?: string
-    tag?: string // 召唤师标识 #12345
-    rank?: string // 当前段位
-    winRate?: number // 胜率（百分比）
-    wins?: number // 胜场
-    losses?: number // 败场
-    totalGames?: number // 总场次
-    createtime: string
+  nickname?: string;
+  avatar?: string;
+  region?: string;
+  tag?: string; // 召唤师标识 #12345
+  rank?: string; // 当前段位
+  winRate?: number; // 胜率（百分比）
+  wins?: number; // 胜场
+  losses?: number; // 败场
+  totalGames?: number; // 总场次
+  createtime: string;
 
-    level?: number // 等级
-    xpSinceLastLevel?: number // 当前等级已获得经验
-    xpUntilNextLevel?: number // 到下一级需要经验
+  level?: number; // 等级
+  xpSinceLastLevel?: number; // 当前等级已获得经验
+  xpUntilNextLevel?: number; // 到下一级需要经验
 }
 
-const useUserStore = defineStore('user', {
-    state: (): UserState => ({
-        nickname: undefined,
-        avatar: undefined,
-        region: '',
-        tag: '',
-        rank: '',
-        winRate: undefined,
-        wins: undefined,
-        losses: undefined,
-        totalGames: undefined,
-        createtime: '',
-    }),
+const useUserStore = defineStore("user", {
+  state: (): UserState => ({
+    nickname: undefined,
+    avatar: undefined,
+    region: "",
+    tag: "",
+    rank: "",
+    winRate: undefined,
+    wins: undefined,
+    losses: undefined,
+    totalGames: undefined,
+    createtime: "",
+    level: undefined,
+    xpSinceLastLevel: undefined,
+    xpUntilNextLevel: undefined,
+  }),
 
-    getters: {
-        userInfo(state): UserState {
-            return { ...state }
-        },
+  getters: {
+    userInfo(state): UserState {
+      return { ...state };
+    },
+  },
+
+  actions: {
+    setInfo(partial: Partial<UserState>) {
+      this.$patch(partial);
     },
 
-    actions: {
-        setInfo(partial: Partial<UserState>) {
-            this.$patch(partial)
-        },
-
-        resetInfo() {
-            this.$reset()
-        },
-
-        async setTokenArr(token: string) {
-            setToken(token)
-        },
-
-        async info() {
-            // const res = await getUserInfo()
-            // this.setInfo(res)
-        },
-
-        async login() {
-            setToken(undefined)
-        },
-
-        async logout(goLogin = false) {
-            // TODO: 清空信息，跳转登录页等
-        },
-
-        clearloginfo() {
-            clearToken()
-        },
+    resetInfo() {
+      this.$reset();
     },
-})
 
-export default useUserStore
+    async setTokenArr(token: string) {
+      setToken(token);
+    },
+
+    async info() {
+      // const res = await getUserInfo()
+      // this.setInfo(res)
+    },
+
+    async login() {
+      setToken(undefined);
+    },
+
+    async logout(goLogin = false) {
+      // TODO: 清空信息，跳转登录页等
+    },
+
+    clearloginfo() {
+      clearToken();
+    },
+  },
+});
+
+export default useUserStore;

--- a/frontend/src/store/modules/user/index.ts
+++ b/frontend/src/store/modules/user/index.ts
@@ -12,7 +12,7 @@ export interface UserState {
   losses?: number; // 败场
   totalGames?: number; // 总场次
   createtime: string;
-
+  server: string;
   level?: number; // 等级
   xpSinceLastLevel?: number; // 当前等级已获得经验
   xpUntilNextLevel?: number; // 到下一级需要经验
@@ -26,6 +26,7 @@ const useUserStore = defineStore("user", {
     tag: "",
     rank: "",
     winRate: undefined,
+    server:"",
     wins: undefined,
     losses: undefined,
     totalGames: undefined,

--- a/frontend/src/views/home/components/Welcome.vue
+++ b/frontend/src/views/home/components/Welcome.vue
@@ -45,6 +45,31 @@ const lcuOnline = ref(false);
 const lcuPort = ref("");
 const lcuToken = ref("");
 
+const loadUserInfo = () => {
+  WailsAPI.GetCurrentSummoner()
+    .then((info: any) => {
+      if (!info) return;
+      userStore.setInfo({
+        nickname: info.displayName,
+        avatar: info.avatar,
+        region: info.region,
+        tag: info.tag,
+        rank: info.rank,
+        winRate: info.winRate,
+        wins: info.wins,
+        losses: info.losses,
+        totalGames: info.totalGames,
+        createtime: info.createtime,
+        level: info.level,
+        xpSinceLastLevel: info.xpSinceLastLevel,
+        xpUntilNextLevel: info.xpUntilNextLevel,
+      });
+    })
+    .catch((err) => {
+      console.error("[GetCurrentSummoner]", err);
+    });
+};
+
 onMounted(() => {
   // 监听系统时间事件
   Events.On("time", (time: any) => {
@@ -67,6 +92,9 @@ onMounted(() => {
     const status = Array.isArray(d.data) ? d.data[0] : d.data;
     if (typeof status === "boolean") {
       lcuOnline.value = status;
+      if (status) {
+        loadUserInfo();
+      }
     } else {
       console.warn("[Event] lcuStatus 数据格式异常:", d.data);
       lcuOnline.value = false; // 或保留上次值
@@ -87,6 +115,9 @@ onMounted(() => {
         "lcuToken:",
         lcuToken.value,
       );
+      if (lcuOnline.value) {
+        loadUserInfo();
+      }
     } else {
       console.warn("[Event] lcuCreds 数据格式异常:", d.data);
       lcuPort.value = "";

--- a/frontend/src/views/home/components/Welcome.vue
+++ b/frontend/src/views/home/components/Welcome.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, onMounted, watch } from "vue";
+import { ref, onMounted } from "vue";
 import { Events } from "@wailsio/runtime";
 import { WailsAPI } from "/#/Soraka/service/lcu";
 import { useUserStore } from "@/store";
@@ -45,24 +45,7 @@ const lcuOnline = ref(false);
 const lcuPort = ref("");
 const lcuToken = ref("");
 
-const loadUserInfo = () => {
-  WailsAPI.GetCurrentSummoner()
-    .then((info: any) => {
-      if (info) {
-        userStore.setInfo({
-          nickname: info.displayName,
-          avatar: `https://127.0.0.1:${lcuPort.value}/lol-game-data/assets/v1/profile-icons/${info.profileIconId}.jpg`,
-          region: info.region,
-        });
-      }
-    })
-    .catch((err: any) => {
-      console.error("[loadUserInfo]", err);
-    });
-};
-
 onMounted(() => {
-
   // 监听系统时间事件
   Events.On("time", (time: any) => {
     // console.log("[Event] time 收到:", time);
@@ -110,18 +93,17 @@ onMounted(() => {
       lcuToken.value = "";
     }
   });
-});
-
-watch(lcuOnline, (online) => {
-  if (online && lcuPort.value) {
-    loadUserInfo();
-  }
-});
-
-watch(lcuPort, (port) => {
-  if (lcuOnline.value && port) {
-    loadUserInfo();
-  }
+  // 接收当前召唤师信息
+  Events.On("summonerInfo", (d: any) => {
+    const info = Array.isArray(d.data) ? d.data[0] : d.data;
+    if (info && typeof info === "object") {
+      userStore.setInfo({
+        nickname: info.displayName,
+        avatar: `https://127.0.0.1:${lcuPort.value}/lol-game-data/assets/v1/profile-icons/${info.profileIconId}.jpg`,
+        region: info.region,
+      });
+    }
+  });
 });
 </script>
 

--- a/frontend/src/views/home/components/Welcome.vue
+++ b/frontend/src/views/home/components/Welcome.vue
@@ -99,8 +99,18 @@ onMounted(() => {
     if (info && typeof info === "object") {
       userStore.setInfo({
         nickname: info.displayName,
-        avatar: `https://127.0.0.1:${lcuPort.value}/lol-game-data/assets/v1/profile-icons/${info.profileIconId}.jpg`,
+        avatar: info.avatar,
         region: info.region,
+        tag: info.tag,
+        rank: info.rank,
+        winRate: info.winRate,
+        wins: info.wins,
+        losses: info.losses,
+        totalGames: info.totalGames,
+        createtime: info.createtime,
+        level: info.level,
+        xpSinceLastLevel: info.xpSinceLastLevel,
+        xpUntilNextLevel: info.xpUntilNextLevel,
       });
     }
   });

--- a/main.go
+++ b/main.go
@@ -1,18 +1,15 @@
 package main
 
 import (
+	example "Soraka/service/example"
 	service "Soraka/service/greet"
+	lcuService "Soraka/service/lcu"
 	"embed"
 	"fmt"
-	"log"
-	"net"
-	"time"
-
 	"github.com/gin-gonic/gin"
 	"github.com/wailsapp/wails/v3/pkg/application"
-
-	example "Soraka/service/example"
-	lcuService "Soraka/service/lcu"
+	"log"
+	"net"
 )
 
 // 前端构建产物
@@ -90,25 +87,37 @@ func main() {
 	// start API server for frontend calls
 	go func() {
 		r := gin.Default()
-		api := &Api{}
+
+		// 初始化 LCU 端口和 token
+		port, token, err := lcuService.GetLolClientApiInfo()
+		if err != nil {
+			log.Printf("初始化 LCU 代理失败: %v", err)
+			// 这里可以考虑降级处理或延迟初始化
+		}
+
+		var rp *lcuService.RP
+		if port > 0 && token != "" {
+			rp, err = lcuService.NewRP(port, token)
+			if err != nil {
+				log.Printf("创建 LCU 反向代理失败: %v", err)
+			}
+		}
+
+		api := &Api{
+			p: &Prophet{
+				LcuActive: true,
+				lcuRP:     rp,
+			},
+		}
+
 		RegisterRoutes(r, api)
+
 		if err := r.Run(":8200"); err != nil {
 			log.Fatal(err)
 		}
 	}()
 
-	// 每秒发送时间事件
-	go func() {
-		fmt.Println("窗口id：", mainWin.ID())
-		for {
-			app.EmitEvent("time", time.Now().Format(time.DateTime))
-			time.Sleep(time.Second)
-		}
-	}()
-
-	// 启动LCU状态监控
-	lcuService.StartNotifier(app)
-
+	lcuService.StartNotifier(mainWin)
 	// 监听前端事件
 	app.OnEvent("myevent", func(e *application.CustomEvent) {
 		fmt.Println("main监听事件：", e)

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -107,61 +106,8 @@ func main() {
 		}
 	}()
 
-	// 实时发送LCU状态、凭证以及当前召唤师信息
-	go func() {
-		var lastStatus bool
-		var lastPort int
-		var lastToken string
-		for {
-			port, token, err := lcuService.GetLolClientApiInfo()
-			status := err == nil
-			if status != lastStatus {
-				app.EmitEvent("lcuStatus", status)
-				lastStatus = status
-			}
-			if status {
-				if port != lastPort || token != lastToken {
-					app.EmitEvent("lcuCreds", lcuService.AuthInfo{Port: port, Token: token})
-					lcuService.InitCli(port, token)
-					if summoner, err := lcuService.GetCurrSummoner(); err == nil {
-						if profile, err := lcuService.GetSummonerProfile(); err == nil {
-							wins, _ := strconv.Atoi(profile.Lol.RankedWins)
-							losses, _ := strconv.Atoi(profile.Lol.RankedLosses)
-							total := wins + losses
-							winRate := 0.0
-							if total > 0 {
-								winRate = float64(wins) * 100 / float64(total)
-							}
-							rank := profile.Lol.RankedLeagueTier
-							if profile.Lol.RankedLeagueDivision != "" {
-								rank = fmt.Sprintf("%s %s", rank, profile.Lol.RankedLeagueDivision)
-							}
-							info := lcuService.SummonerInfo{
-								DisplayName:      summoner.DisplayName,
-								ProfileIconId:    summoner.ProfileIconId,
-								Region:           summoner.TagLine,
-								Avatar:           fmt.Sprintf("https://127.0.0.1:%d/lol-game-data/assets/v1/profile-icons/%d.jpg", port, summoner.ProfileIconId),
-								Tag:              "#" + summoner.GameTag,
-								Rank:             rank,
-								WinRate:          winRate,
-								Wins:             wins,
-								Losses:           losses,
-								TotalGames:       total,
-								Createtime:       time.Now().Format(time.DateTime),
-								Level:            summoner.SummonerLevel,
-								XpSinceLastLevel: summoner.XpSinceLastLevel,
-								XpUntilNextLevel: summoner.XpUntilNextLevel,
-							}
-							app.EmitEvent("summonerInfo", info)
-						}
-					}
-					lastPort = port
-					lastToken = token
-				}
-			}
-			time.Sleep(time.Second)
-		}
-	}()
+	// 启动LCU状态监控
+	lcuService.StartNotifier(app)
 
 	// 监听前端事件
 	app.OnEvent("myevent", func(e *application.CustomEvent) {

--- a/routes.go
+++ b/routes.go
@@ -26,5 +26,5 @@ func initV1Module(r *gin.Engine, api *Api) {
 	// 复制马匹信息到剪切板
 	v1.POST("horse/copyHorseMsgToClipBoard", api.CopyHorseMsgToClipBoard)
 	// lcu proxy
-	v1.Any("lcu/proxy/*any", api.LcuProxy)
+	v1.Any("/lcu/proxy/*any", api.LcuProxy)
 }

--- a/service/lcu/lcu_test.go
+++ b/service/lcu/lcu_test.go
@@ -4,20 +4,38 @@ import (
 	"testing"
 )
 
-func TestGetLolClientApiInfoV3_Real(t *testing.T) {
-	port, token, err := GetLolClientApiInfoV3()
-
+func TestGetCurrentSummoner(t *testing.T) {
+	// 1. 获取 port + token
+	port, token, err := GetLolClientApiInfo()
 	if err != nil {
-		t.Logf("Expected: LeagueClientUx.exe not running or not matched, got error: %v", err)
-		return // 如果没在运行，直接退出，不算失败
+		t.Fatalf("GetLolClientApiInfo failed: %v", err)
 	}
 
-	if port <= 0 {
-		t.Errorf("Expected positive port, got %d", port)
-	}
-	if token == "" {
-		t.Errorf("Expected non-empty token, got empty string")
+	// 2. 初始化 CLI 客户端（很关键）
+	InitCli(port, token)
+
+	// 3. 正常调用主函数
+	info, err := WailsAPI{}.GetCurrentSummoner()
+	if err != nil {
+		t.Fatalf("GetCurrentSummoner returned error: %v", err)
 	}
 
-	t.Logf("Got port: %d, token: %s", port, token)
+	// 4. 验证结果
+	if info.DisplayName == "" {
+		t.Error("DisplayName is empty")
+	}
+	if info.ProfileIconId == 0 {
+		t.Error("ProfileIconId is 0")
+	}
+	if info.Level <= 0 {
+		t.Errorf("Invalid Level: %d", info.Level)
+	}
+	if info.Avatar == "" {
+		t.Error("Avatar is empty")
+	}
+	if info.TotalGames != info.Wins+info.Losses {
+		t.Errorf("TotalGames mismatch: got %d, expected %d", info.TotalGames, info.Wins+info.Losses)
+	}
+
+	t.Logf("✅ SummonerInfo: %+v", info)
 }

--- a/service/lcu/notifier.go
+++ b/service/lcu/notifier.go
@@ -1,36 +1,47 @@
 package lcu
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
 )
 
-// StartNotifier emits LCU status, credentials and summoner info events.
-func StartNotifier(app *application.App) {
+func StartNotifier(win *application.WebviewWindow) {
 	go func() {
-		var lastStatus bool
-		var lastPort int
-		var lastToken string
+		tickerTime := time.NewTicker(time.Second)       // 每秒
+		tickerOthers := time.NewTicker(5 * time.Second) // 每 5 秒
+
+		defer tickerTime.Stop()
+		defer tickerOthers.Stop()
+
 		for {
-			port, token, err := GetLolClientApiInfo()
-			status := err == nil
-			if status != lastStatus {
-				app.EmitEvent("lcuStatus", status)
-				lastStatus = status
-			}
-			if status {
-				if port != lastPort || token != lastToken {
-					app.EmitEvent("lcuCreds", AuthInfo{Port: port, Token: token})
+			select {
+			case t := <-tickerTime.C:
+				// 每秒发送当前时间字符串
+				win.EmitEvent("time", t.Format(time.DateTime))
+
+			case <-tickerOthers.C:
+				// 每 5 秒发送 LCU 状态、端口、Token、召唤师信息
+				port, token, err := GetLolClientApiInfo()
+				status := err == nil
+				win.EmitEvent("lcuStatus", map[string]any{"status": status})
+
+				if status {
+					win.EmitEvent("lcuCreds", map[string]any{
+						"port":  port,
+						"token": token,
+					})
+
 					InitCli(port, token)
+
 					if info, err := (WailsAPI{}).GetCurrentSummoner(); err == nil {
-						app.EmitEvent("summonerInfo", info)
+						win.EmitEvent("summonerInfo", info)
+					} else {
+						fmt.Println("[Notifier] 获取召唤师信息失败:", err)
 					}
-					lastPort = port
-					lastToken = token
 				}
 			}
-			time.Sleep(time.Second)
 		}
 	}()
 }

--- a/service/lcu/notifier.go
+++ b/service/lcu/notifier.go
@@ -1,0 +1,36 @@
+package lcu
+
+import (
+	"time"
+
+	"github.com/wailsapp/wails/v3/pkg/application"
+)
+
+// StartNotifier emits LCU status, credentials and summoner info events.
+func StartNotifier(app *application.App) {
+	go func() {
+		var lastStatus bool
+		var lastPort int
+		var lastToken string
+		for {
+			port, token, err := GetLolClientApiInfo()
+			status := err == nil
+			if status != lastStatus {
+				app.EmitEvent("lcuStatus", status)
+				lastStatus = status
+			}
+			if status {
+				if port != lastPort || token != lastToken {
+					app.EmitEvent("lcuCreds", AuthInfo{Port: port, Token: token})
+					InitCli(port, token)
+					if info, err := (WailsAPI{}).GetCurrentSummoner(); err == nil {
+						app.EmitEvent("summonerInfo", info)
+					}
+					lastPort = port
+					lastToken = token
+				}
+			}
+			time.Sleep(time.Second)
+		}
+	}()
+}


### PR DESCRIPTION
## Summary
- watch LCU connection and creds in Welcome component
- load user info from LCU when connection is established
- emit `lcuStatus` and `lcuCreds` events from backend

## Testing
- `go test ./...` *(fails: Forbidden)*
- `npm run build --prefix frontend` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856bc7d2870832d9d1fae1254cb01c7