### PR TITLE
Add Data Dragon cache on startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"Soraka/dal/logger"
+	ddragon "Soraka/service/ddragon"
 	example "Soraka/service/example"
 	service "Soraka/service/greet"
 	lcuService "Soraka/service/lcu"
@@ -118,6 +119,9 @@ func main() {
 	//}()
 	// 初始化 logger
 	logger.Init()
+	if err := ddragon.UpdateIconCache(); err != nil {
+		log.Printf("update icon cache failed: %v", err)
+	}
 
 	prophet := NewProphet()
 	go func() {

--- a/main.go
+++ b/main.go
@@ -119,8 +119,12 @@ func main() {
 	//}()
 	// 初始化 logger
 	logger.Init()
-	if err := ddragon.UpdateIconCache(); err != nil {
-		log.Printf("update icon cache failed: %v", err)
+	if _, _, err := lcuService.GetLolClientApiInfo(); err == nil {
+		if err := ddragon.UpdateIconCache(); err != nil {
+			log.Printf("update icon cache failed: %v", err)
+		}
+	} else if err != lcuService.ErrLolProcessNotFound {
+		log.Printf("check lol client failed: %v", err)
 	}
 
 	prophet := NewProphet()

--- a/main.go
+++ b/main.go
@@ -119,9 +119,11 @@ func main() {
 	//}()
 	// 初始化 logger
 	logger.Init()
-	if _, _, err := lcuService.GetLolClientApiInfo(); err == nil {
-		if err := ddragon.UpdateIconCache(); err != nil {
-			log.Printf("update icon cache failed: %v", err)
+	if port, token, err := lcuService.GetLolClientApiInfo(); err == nil {
+		if port != 0 && token != "" {
+			if err := ddragon.UpdateIconCache(port, token); err != nil {
+				log.Printf("update icon cache failed: %v", err)
+			}
 		}
 	} else if err != lcuService.ErrLolProcessNotFound {
 		log.Printf("check lol client failed: %v", err)

--- a/service/ddragon/ddragon.go
+++ b/service/ddragon/ddragon.go
@@ -9,11 +9,19 @@ import (
 	"os"
 	"path/filepath"
 	"time"
-
-	lcu "Soraka/service/lcu"
 )
 
 const iconBaseDir = "bin/icon"
+
+const (
+	authUserName = "riot"
+	host         = "127.0.0.1"
+	httpScheme   = "https"
+)
+
+func clientURL(port int, token string) string {
+	return fmt.Sprintf("%s://%s:%s@%s:%d", httpScheme, authUserName, token, host, port)
+}
 
 var httpCli = &http.Client{
 	Transport: &http.Transport{
@@ -23,7 +31,7 @@ var httpCli = &http.Client{
 }
 
 func getGameVersion(port int, token string) (string, error) {
-	url := fmt.Sprintf("%s/lol-patch/v1/game-version", lcu.GenerateClientApiUrl(port, token))
+	url := fmt.Sprintf("%s/lol-patch/v1/game-version", clientURL(port, token))
 	resp, err := httpCli.Get(url)
 	if err != nil {
 		return "", err
@@ -67,7 +75,7 @@ func UpdateIconCache(port int, token string) error {
 }
 
 func downloadItems(port int, token string) error {
-	url := fmt.Sprintf("%s/lol-game-data/assets/v1/items.json", lcu.GenerateClientApiUrl(port, token))
+	url := fmt.Sprintf("%s/lol-game-data/assets/v1/items.json", clientURL(port, token))
 	resp, err := httpCli.Get(url)
 	if err != nil {
 		return err
@@ -91,7 +99,7 @@ func downloadItems(port int, token string) error {
 		if v.Image.Full == "" {
 			continue
 		}
-		src := fmt.Sprintf("%s/lol-game-data/assets/v1/items/%s", lcu.GenerateClientApiUrl(port, token), v.Image.Full)
+		src := fmt.Sprintf("%s/lol-game-data/assets/v1/items/%s", clientURL(port, token), v.Image.Full)
 		dst := filepath.Join(dir, v.Image.Full)
 		if err := downloadFile(src, dst); err != nil {
 			return err
@@ -101,7 +109,7 @@ func downloadItems(port int, token string) error {
 }
 
 func downloadSummoners(port int, token string) error {
-	url := fmt.Sprintf("%s/lol-game-data/assets/v1/summoner-spells.json", lcu.GenerateClientApiUrl(port, token))
+	url := fmt.Sprintf("%s/lol-game-data/assets/v1/summoner-spells.json", clientURL(port, token))
 	resp, err := httpCli.Get(url)
 	if err != nil {
 		return err
@@ -125,7 +133,7 @@ func downloadSummoners(port int, token string) error {
 		if v.Image.Full == "" {
 			continue
 		}
-		src := fmt.Sprintf("%s/lol-game-data/assets/v1/summoner-spells/%s", lcu.GenerateClientApiUrl(port, token), v.Image.Full)
+		src := fmt.Sprintf("%s/lol-game-data/assets/v1/summoner-spells/%s", clientURL(port, token), v.Image.Full)
 		dst := filepath.Join(dir, v.Image.Full)
 		if err := downloadFile(src, dst); err != nil {
 			return err
@@ -135,7 +143,7 @@ func downloadSummoners(port int, token string) error {
 }
 
 func downloadProfileIcons(port int, token string) error {
-	url := fmt.Sprintf("%s/lol-game-data/assets/v1/profileicon.json", lcu.GenerateClientApiUrl(port, token))
+	url := fmt.Sprintf("%s/lol-game-data/assets/v1/profileicon.json", clientURL(port, token))
 	resp, err := httpCli.Get(url)
 	if err != nil {
 		return err
@@ -159,7 +167,7 @@ func downloadProfileIcons(port int, token string) error {
 		if v.Image.Full == "" {
 			continue
 		}
-		src := fmt.Sprintf("%s/lol-game-data/assets/v1/profile-icons/%s", lcu.GenerateClientApiUrl(port, token), v.Image.Full)
+		src := fmt.Sprintf("%s/lol-game-data/assets/v1/profile-icons/%s", clientURL(port, token), v.Image.Full)
 		dst := filepath.Join(dir, v.Image.Full)
 		if err := downloadFile(src, dst); err != nil {
 			return err
@@ -169,7 +177,7 @@ func downloadProfileIcons(port int, token string) error {
 }
 
 func downloadRunes(port int, token string) error {
-	url := fmt.Sprintf("%s/lol-game-data/assets/v1/perkstyles.json", lcu.GenerateClientApiUrl(port, token))
+	url := fmt.Sprintf("%s/lol-game-data/assets/v1/perkstyles.json", clientURL(port, token))
 	resp, err := httpCli.Get(url)
 	if err != nil {
 		return err
@@ -208,7 +216,7 @@ func downloadRunes(port int, token string) error {
 
 func saveRuneIcon(iconPath, base string, port int, token string) error {
 	dst := filepath.Join(base, iconPath)
-	src := fmt.Sprintf("%s/lol-game-data/assets/%s", lcu.GenerateClientApiUrl(port, token), iconPath)
+	src := fmt.Sprintf("%s/lol-game-data/assets/%s", clientURL(port, token), iconPath)
 	return downloadFile(src, dst)
 }
 

--- a/service/ddragon/ddragon.go
+++ b/service/ddragon/ddragon.go
@@ -1,0 +1,243 @@
+package ddragon
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+const iconBaseDir = "bin/icon"
+
+func GetLatestVersion() (string, error) {
+	resp, err := http.Get("https://ddragon.leagueoflegends.com/api/versions.json")
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	var vers []string
+	if err := json.NewDecoder(resp.Body).Decode(&vers); err != nil {
+		return "", err
+	}
+	if len(vers) == 0 {
+		return "", fmt.Errorf("no version info")
+	}
+	return vers[0], nil
+}
+
+func UpdateIconCache() error {
+	ver, err := GetLatestVersion()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(iconBaseDir, 0755); err != nil {
+		return err
+	}
+	vf := filepath.Join(iconBaseDir, "version.txt")
+	if b, err := os.ReadFile(vf); err == nil && string(b) == ver {
+		return nil
+	}
+	if err := downloadItems(ver); err != nil {
+		return err
+	}
+	if err := downloadSummoners(ver); err != nil {
+		return err
+	}
+	if err := downloadProfileIcons(ver); err != nil {
+		return err
+	}
+	if err := downloadRunes(ver); err != nil {
+		return err
+	}
+	return os.WriteFile(vf, []byte(ver), 0644)
+}
+
+func downloadItems(ver string) error {
+	url := fmt.Sprintf("https://ddragon.leagueoflegends.com/cdn/%s/data/en_US/item.json", ver)
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var data struct {
+		Data map[string]struct {
+			Image struct {
+				Full string `json:"full"`
+			} `json:"image"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return err
+	}
+	dir := filepath.Join(iconBaseDir, "item")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	for _, v := range data.Data {
+		if v.Image.Full == "" {
+			continue
+		}
+		src := fmt.Sprintf("https://ddragon.leagueoflegends.com/cdn/%s/img/item/%s", ver, v.Image.Full)
+		dst := filepath.Join(dir, v.Image.Full)
+		if err := downloadFile(src, dst); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func downloadSummoners(ver string) error {
+	url := fmt.Sprintf("https://ddragon.leagueoflegends.com/cdn/%s/data/en_US/summoner.json", ver)
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var data struct {
+		Data map[string]struct {
+			Image struct {
+				Full string `json:"full"`
+			} `json:"image"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return err
+	}
+	dir := filepath.Join(iconBaseDir, "summoner")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	for _, v := range data.Data {
+		if v.Image.Full == "" {
+			continue
+		}
+		src := fmt.Sprintf("https://ddragon.leagueoflegends.com/cdn/%s/img/spell/%s", ver, v.Image.Full)
+		dst := filepath.Join(dir, v.Image.Full)
+		if err := downloadFile(src, dst); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func downloadProfileIcons(ver string) error {
+	url := fmt.Sprintf("https://ddragon.leagueoflegends.com/cdn/%s/data/en_US/profileicon.json", ver)
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var data struct {
+		Data map[string]struct {
+			Image struct {
+				Full string `json:"full"`
+			} `json:"image"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return err
+	}
+	dir := filepath.Join(iconBaseDir, "profileicon")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	for _, v := range data.Data {
+		if v.Image.Full == "" {
+			continue
+		}
+		src := fmt.Sprintf("https://ddragon.leagueoflegends.com/cdn/%s/img/profileicon/%s", ver, v.Image.Full)
+		dst := filepath.Join(dir, v.Image.Full)
+		if err := downloadFile(src, dst); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func downloadRunes(ver string) error {
+	url := fmt.Sprintf("https://ddragon.leagueoflegends.com/cdn/%s/data/en_US/runesReforged.json", ver)
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var trees []struct {
+		Icon  string `json:"icon"`
+		Slots []struct {
+			Runes []struct {
+				Icon string `json:"icon"`
+			} `json:"runes"`
+		} `json:"slots"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&trees); err != nil {
+		return err
+	}
+	dir := filepath.Join(iconBaseDir, "runes")
+	for _, t := range trees {
+		if t.Icon != "" {
+			if err := saveRuneIcon(t.Icon, dir); err != nil {
+				return err
+			}
+		}
+		for _, s := range t.Slots {
+			for _, r := range s.Runes {
+				if r.Icon != "" {
+					if err := saveRuneIcon(r.Icon, dir); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func saveRuneIcon(iconPath, base string) error {
+	dst := filepath.Join(base, iconPath)
+	src := fmt.Sprintf("https://ddragon.leagueoflegends.com/cdn/img/%s", iconPath)
+	return downloadFile(src, dst)
+}
+
+func downloadFile(url, dst string) error {
+	if _, err := os.Stat(dst); err == nil {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	f, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = io.Copy(f, resp.Body)
+	return err
+}
+
+func FindIconPath(name string) (string, error) {
+	var result string
+	err := filepath.Walk(iconBaseDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() && info.Name() == name {
+			result = path
+			return filepath.SkipDir
+		}
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	if result == "" {
+		return "", fmt.Errorf("icon %s not found", name)
+	}
+	return result, nil
+}

--- a/service/ddragon/ddragon.go
+++ b/service/ddragon/ddragon.go
@@ -203,6 +203,7 @@ func downloadChampions(port int, token string) error {
 		if err := downloadFile(src, dst); err != nil {
 			return err
 		}
+		ChampionIcons[c.ID] = dst
 	}
 	return nil
 }
@@ -217,6 +218,7 @@ func downloadItems(port int, token string) error {
 		src := fmt.Sprintf("%s%s", clientURL(port, token), item.IconPath)
 		fileName := filepath.Base(item.IconPath)
 		dst := filepath.Join(dir, fileName)
+		ItemIcons[item.ID] = dst
 	var data []struct {
 		ID       int    `json:"id"`
 		IconPath string `json:"iconPath"`
@@ -225,6 +227,7 @@ func downloadItems(port int, token string) error {
 		src := fmt.Sprintf("%s%s", clientURL(port, token), sp.IconPath)
 		fileName := filepath.Base(sp.IconPath)
 		dst := filepath.Join(dir, fileName)
+		SpellIcons[sp.ID] = dst
 
 	var data []struct {
 		ID       int    `json:"id"`

--- a/service/ddragon/ddragon.go
+++ b/service/ddragon/ddragon.go
@@ -19,6 +19,13 @@ const (
 	httpScheme   = "https"
 )
 
+// Icon mappings built when UpdateIconCache runs
+var (
+	ItemIcons     = map[int]string{}
+	SpellIcons    = map[int]string{}
+	ChampionIcons = map[int]string{}
+)
+
 func clientURL(port int, token string) string {
 	return fmt.Sprintf("%s://%s:%s@%s:%d", httpScheme, authUserName, token, host, port)
 }
@@ -56,13 +63,33 @@ func UpdateIconCache(port int, token string) error {
 		return err
 	}
 	vf := filepath.Join(iconBaseDir, "version.txt")
+	cached := false
 	if b, err := os.ReadFile(vf); err == nil && string(b) == ver {
+		cached = true
+	}
+
+	// always refresh icon mappings
+	if err := loadItemMap(port, token); err != nil {
+		return err
+	}
+	if err := loadSpellMap(port, token); err != nil {
+		return err
+	}
+	if err := loadChampionMap(port, token); err != nil {
+		return err
+	}
+
+	if cached {
 		return nil
 	}
+
 	if err := downloadItems(port, token); err != nil {
 		return err
 	}
 	if err := downloadSummoners(port, token); err != nil {
+		return err
+	}
+	if err := downloadChampions(port, token); err != nil {
 		return err
 	}
 	if err := downloadProfileIcons(port, token); err != nil {
@@ -73,39 +100,140 @@ func UpdateIconCache(port int, token string) error {
 	}
 	return os.WriteFile(vf, []byte(ver), 0644)
 }
-func downloadItems(port int, token string) error {
+func loadItemMap(port int, token string) error {
 	url := fmt.Sprintf("%s/lol-game-data/assets/v1/items.json", clientURL(port, token))
-	fmt.Printf("请求 items.json: %s\n", url)
-
 	resp, err := httpCli.Get(url)
 	if err != nil {
-		return fmt.Errorf("请求 items.json 失败: %w", err)
+		return err
 	}
 	defer resp.Body.Close()
-
 	var data []struct {
 		ID       int    `json:"id"`
 		IconPath string `json:"iconPath"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
-		return fmt.Errorf("解析 items.json 失败: %w", err)
+		return err
 	}
-
-	dir := filepath.Join(iconBaseDir, "item")
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("创建目录失败: %w", err)
-	}
-
-	for _, item := range data {
-		if item.IconPath == "" {
+	ItemIcons = map[int]string{}
+	for _, it := range data {
+		if it.IconPath == "" {
 			continue
 		}
+		name := filepath.Base(it.IconPath)
+		ItemIcons[it.ID] = filepath.Join(iconBaseDir, "item", name)
+	}
+	return nil
+}
+
+func loadSpellMap(port int, token string) error {
+	url := fmt.Sprintf("%s/lol-game-data/assets/v1/summoner-spells.json", clientURL(port, token))
+	resp, err := httpCli.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var data []struct {
+		ID       int    `json:"id"`
+		IconPath string `json:"iconPath"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return err
+	}
+	SpellIcons = map[int]string{}
+	for _, sp := range data {
+		if sp.IconPath == "" {
+			continue
+		}
+		name := filepath.Base(sp.IconPath)
+		SpellIcons[sp.ID] = filepath.Join(iconBaseDir, "summoner", name)
+	}
+	return nil
+}
+
+func loadChampionMap(port int, token string) error {
+	url := fmt.Sprintf("%s/lol-game-data/assets/v1/champion-summary.json", clientURL(port, token))
+	resp, err := httpCli.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var data []struct {
+		ID       int    `json:"id"`
+		IconPath string `json:"squarePortraitPath"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return err
+	}
+	ChampionIcons = map[int]string{}
+	for _, ch := range data {
+		if ch.IconPath == "" {
+			continue
+		}
+		name := filepath.Base(ch.IconPath)
+		ChampionIcons[ch.ID] = filepath.Join(iconBaseDir, "champion", name)
+	}
+	return nil
+}
+
+func downloadChampions(port int, token string) error {
+	url := fmt.Sprintf("%s/lol-game-data/assets/v1/champion-summary.json", clientURL(port, token))
+	resp, err := httpCli.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	var data []struct {
+		ID       int    `json:"id"`
+		IconPath string `json:"squarePortraitPath"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return err
+	}
+	dir := filepath.Join(iconBaseDir, "champion")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	for _, c := range data {
+		if c.IconPath == "" {
+			continue
+		}
+		src := fmt.Sprintf("%s%s", clientURL(port, token), c.IconPath)
+		fileName := filepath.Base(c.IconPath)
+		dst := filepath.Join(dir, fileName)
+		if err := downloadFile(src, dst); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func downloadItems(port int, token string) error {
+	url := fmt.Sprintf("%s/lol-game-data/assets/v1/items.json", clientURL(port, token))
+	var data []struct {
+		ID       int    `json:"id"`
+		IconPath string `json:"iconPath"`
+	for _, item := range data {
+		if item.IconPath == "" {
 		src := fmt.Sprintf("%s%s", clientURL(port, token), item.IconPath)
 		fileName := filepath.Base(item.IconPath)
 		dst := filepath.Join(dir, fileName)
+	var data []struct {
+		ID       int    `json:"id"`
+		IconPath string `json:"iconPath"`
+	for _, sp := range data {
+		if sp.IconPath == "" {
+		src := fmt.Sprintf("%s%s", clientURL(port, token), sp.IconPath)
+		fileName := filepath.Base(sp.IconPath)
+		dst := filepath.Join(dir, fileName)
 
-		fmt.Printf("下载: %s -> %s\n", src, dst)
-		if err := downloadFile(src, dst); err != nil {
+	var data []struct {
+		ID       int    `json:"id"`
+		IconPath string `json:"iconPath"`
+	for _, ic := range data {
+		if ic.IconPath == "" {
+		src := fmt.Sprintf("%s%s", clientURL(port, token), ic.IconPath)
+		fileName := filepath.Base(ic.IconPath)
+		dst := filepath.Join(dir, fileName)
 			fmt.Printf("⚠️ 下载失败: %v（继续）\n", err)
 			continue
 		}
@@ -237,6 +365,33 @@ func downloadFile(url, dst string) error {
 	if err != nil {
 		return err
 	}
+
+func ItemIconURL(id int) string {
+	if p, ok := ItemIcons[id]; ok {
+		if abs, err := filepath.Abs(p); err == nil {
+			return "file://" + filepath.ToSlash(abs)
+		}
+	}
+	return ""
+}
+
+func SpellIconURL(id int) string {
+	if p, ok := SpellIcons[id]; ok {
+		if abs, err := filepath.Abs(p); err == nil {
+			return "file://" + filepath.ToSlash(abs)
+		}
+	}
+	return ""
+}
+
+func ChampionIconURL(id int) string {
+	if p, ok := ChampionIcons[id]; ok {
+		if abs, err := filepath.Abs(p); err == nil {
+			return "file://" + filepath.ToSlash(abs)
+		}
+	}
+	return ""
+}
 	defer resp.Body.Close()
 	f, err := os.Create(dst)
 	if err != nil {

--- a/service/lcu/lcu_test.go
+++ b/service/lcu/lcu_test.go
@@ -1,7 +1,9 @@
 package lcu
 
 import (
+	"Soraka/service/ddragon"
 	"fmt"
+	"log"
 	"testing"
 )
 
@@ -61,4 +63,20 @@ func TestListRecentMatchesSimple(t *testing.T) {
 		fmt.Printf("Map: %s\n", match.Map)
 		fmt.Println("--------------------------")
 	}
+}
+func TestGetLolClientApiInfo(t *testing.T) {
+	// 获取 LCU 客户端 port + token
+	port, token, err := GetLolClientApiInfo()
+	if err != nil {
+		log.Fatalf("获取 LCU 客户端信息失败: %v", err)
+	}
+
+	fmt.Printf("开始更新图标缓存 (port: %d)\n", port)
+
+	// 调用 UpdateIconCache
+	if err := ddragon.UpdateIconCache(port, token); err != nil {
+		log.Fatalf("UpdateIconCache 失败: %v", err)
+	}
+
+	fmt.Println("✅ 图标缓存更新成功！")
 }

--- a/service/lcu/match.go
+++ b/service/lcu/match.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"Soraka/dal/lcu/models"
+	ddragon "Soraka/service/ddragon"
 )
 
 type MatchBrief struct {
@@ -88,11 +89,11 @@ func ListRecentMatches(limit int) ([]MatchBrief, error) {
 				if id == 0 {
 					continue
 				}
-				items = append(items, models.ItemIconURL(id))
+				items = append(items, ddragon.ItemIconURL(id))
 			}
 			spells := []string{
-				models.SpellIconURL(int(p.Spell1Id)),
-				models.SpellIconURL(int(p.Spell2Id)),
+				ddragon.SpellIconURL(int(p.Spell1Id)),
+				ddragon.SpellIconURL(int(p.Spell2Id)),
 			}
 			mb := MatchBrief{
 				ID:       g.GameId,
@@ -105,7 +106,7 @@ func ListRecentMatches(limit int) ([]MatchBrief, error) {
 				Gold:     p.Stats.GoldEarned,
 				Time:     time.UnixMilli(g.GameCreation).Format("2006/01/02 15:04"),
 				Level:    p.Stats.ChampLevel,
-				Champion: models.ChampionIconURL(int(p.ChampionId)),
+				Champion: ddragon.ChampionIconURL(int(p.ChampionId)),
 				Spells:   spells,
 				Items:    items,
 				Map:      mapMap(models.MapID(g.MapId)),

--- a/service/lcu/notifier.go
+++ b/service/lcu/notifier.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	ddragon "Soraka/service/ddragon"
 	"github.com/wailsapp/wails/v3/pkg/application"
 )
 
@@ -14,6 +15,8 @@ func StartNotifier(win *application.WebviewWindow) {
 
 		defer tickerTime.Stop()
 		defer tickerOthers.Stop()
+
+		var connected bool
 
 		for {
 			select {
@@ -35,12 +38,19 @@ func StartNotifier(win *application.WebviewWindow) {
 
 					InitCli(port, token)
 
+					if !connected {
+						if err := ddragon.UpdateIconCache(port, token); err != nil {
+							fmt.Println("[Notifier] icon cache update failed:", err)
+						}
+					}
+
 					if info, err := (WailsAPI{}).GetCurrentSummoner(); err == nil {
 						win.EmitEvent("summonerInfo", info)
 					} else {
 						fmt.Println("[Notifier] 获取召唤师信息失败:", err)
 					}
 				}
+				connected = status
 			}
 		}
 	}()

--- a/service/lcu/notifier.go
+++ b/service/lcu/notifier.go
@@ -1,10 +1,10 @@
 package lcu
 
 import (
+	"Soraka/service/ddragon"
 	"fmt"
 	"time"
 
-	ddragon "Soraka/service/ddragon"
 	"github.com/wailsapp/wails/v3/pkg/application"
 )
 


### PR DESCRIPTION
## Summary
- integrate `ddragon` package
- update icon cache when the app launches

## Testing
- `go vet ./...` *(fails: forbidden to access proxy)*
- `go test ./...` *(fails: forbidden to access proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68574a72f418832d9585b339677e14ec