### PR TITLE
Refactor backend structure with sqlite

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"log"
+
+	"github.com/gin-gonic/gin"
+
+	"Soraka/internal/db"
+	"Soraka/internal/router"
+)
+
+func main() {
+	if err := db.Init(); err != nil {
+		log.Fatalf("init db: %v", err)
+	}
+	r := gin.Default()
+	router.Register(r)
+	if err := r.Run(":8080"); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -18,9 +18,10 @@ require (
 	go.opentelemetry.io/contrib/processors/minsev v0.9.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.9.0
-	golang.org/x/sys v0.33.0
-	golang.org/x/time v0.7.0
-	gorm.io/gorm v1.25.12
+        golang.org/x/sys v0.33.0
+        golang.org/x/time v0.7.0
+        gorm.io/gorm v1.25.12
+        gorm.io/driver/sqlite v1.4.7
 )
 
 require (

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,0 +1,22 @@
+package db
+
+import (
+	"Soraka/conf"
+	"Soraka/global"
+	"Soraka/internal/model"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func Init() error {
+	db, err := gorm.Open(sqlite.Open(conf.SqliteDBPath), &gorm.Config{})
+	if err != nil {
+		return err
+	}
+	if err := db.AutoMigrate(&model.Config{}); err != nil {
+		return err
+	}
+	global.SqliteDB = db
+	return nil
+}

--- a/internal/handler/config.go
+++ b/internal/handler/config.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"Soraka/internal/service"
+)
+
+type SaveConfigReq struct {
+	Key string `json:"key" binding:"required"`
+	Val string `json:"val" binding:"required"`
+}
+
+func SaveConfig(c *gin.Context) {
+	var req SaveConfigReq
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if err := service.SaveConfig(req.Key, req.Val); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+func GetConfig(c *gin.Context) {
+	key := c.Query("key")
+	val, err := service.GetConfig(key)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"key": key, "val": val})
+}

--- a/internal/model/config.go
+++ b/internal/model/config.go
@@ -1,0 +1,14 @@
+package model
+
+import "gorm.io/gorm"
+
+// Config stores simple key/value settings.
+type Config struct {
+	gorm.Model
+	Key string `gorm:"column:k;uniqueIndex"`
+	Val string `gorm:"column:v"`
+}
+
+func (Config) TableName() string {
+	return "config"
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,0 +1,13 @@
+package router
+
+import (
+	"github.com/gin-gonic/gin"
+
+	"Soraka/internal/handler"
+)
+
+// Register binds all routes to the gin engine.
+func Register(r *gin.Engine) {
+	r.POST("/config", handler.SaveConfig)
+	r.GET("/config", handler.GetConfig)
+}

--- a/internal/service/config.go
+++ b/internal/service/config.go
@@ -1,0 +1,26 @@
+package service
+
+import (
+	"Soraka/global"
+	"Soraka/internal/model"
+	"gorm.io/gorm/clause"
+)
+
+// SaveConfig stores or updates a config entry.
+func SaveConfig(key, val string) error {
+	cfg := &model.Config{Key: key, Val: val}
+	return global.SqliteDB.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "k"}},
+		DoUpdates: clause.Assignments(map[string]interface{}{"v": val}),
+	}).Create(cfg).Error
+}
+
+// GetConfig returns the stored value for a key.
+func GetConfig(key string) (string, error) {
+	var cfg model.Config
+	err := global.SqliteDB.Where("k = ?", key).First(&cfg).Error
+	if err != nil {
+		return "", err
+	}
+	return cfg.Val, nil
+}


### PR DESCRIPTION
## Summary
- add modular server under `cmd/server`
- implement sqlite initialization
- create config model and service
- expose config HTTP endpoints via new router
- add sqlite driver dependency

## Testing
- `go mod tidy` *(fails: network access blocked)*
- `go vet ./...` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6857f8a6b4cc832daaacbdaae0dabb30