### PR TITLE
Fix wails warnings by wrapping services

### DIFF
--- a/internal/router/basic.go
+++ b/internal/router/basic.go
@@ -28,6 +28,7 @@ func (r *BasicRouter) InitRouter(root *gin.RouterGroup) {
 }
 
 func (r *BasicRouter) CollectWailsServices(services *[]application.Service) {
-	*services = append(*services, application.NewService(r.greetService))
+	ws := greet.NewWailsService(r.greetService)
+	*services = append(*services, application.NewService(ws))
 	//*services = append(*services, application.NewService(r.lcuApiService))
 }

--- a/internal/router/lcu.go
+++ b/internal/router/lcu.go
@@ -22,5 +22,6 @@ func (r *LcuRouter) InitRouter(root *gin.RouterGroup) {
 	r.lcuApiService.RegisterGin(group)
 }
 func (r *LcuRouter) CollectWailsServices(services *[]application.Service) {
-	*services = append(*services, application.NewService(r.lcuApiService))
+	ws := lcu.NewWailsService(r.lcuApiService)
+	*services = append(*services, application.NewService(ws))
 }

--- a/internal/service/greet/wails.go
+++ b/internal/service/greet/wails.go
@@ -1,0 +1,21 @@
+package greet
+
+// WailsService exposes only methods intended for the frontend.
+type WailsService struct {
+	svc *GreetService
+}
+
+// NewWailsService wraps a GreetService for use with Wails.
+func NewWailsService(svc *GreetService) *WailsService {
+	return &WailsService{svc: svc}
+}
+
+// Name returns the service name.
+func (w *WailsService) Name() string {
+	return w.svc.Name()
+}
+
+// SetTheme forwards the call to the underlying service.
+func (w *WailsService) SetTheme() {
+	w.svc.SetTheme()
+}

--- a/internal/service/lcu/wails.go
+++ b/internal/service/lcu/wails.go
@@ -1,0 +1,21 @@
+package lcu
+
+// WailsService exposes only methods intended for the frontend.
+type WailsService struct {
+	svc *LcuApiService
+}
+
+// NewWailsService wraps a LcuApiService for use with Wails.
+func NewWailsService(svc *LcuApiService) *WailsService {
+	return &WailsService{svc: svc}
+}
+
+// Name returns the service name.
+func (w *WailsService) Name() string {
+	return w.svc.Name()
+}
+
+// GetClientPath forwards the call to the underlying service.
+func (w *WailsService) GetClientPath() (string, error) {
+	return w.svc.GetClientPath()
+}


### PR DESCRIPTION
## Summary
- prevent gin-specific methods from being exported to Wails
- expose small wrappers for frontend use

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685996bb1658832d945d307329f8e8c8