### PR TITLE
Add stats search UI

### DIFF
--- a/frontend/src/views/stats/components/SearchFilterHeader.vue
+++ b/frontend/src/views/stats/components/SearchFilterHeader.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="filter-header">
+    <a-input v-model="keyword" placeholder="召唤师昵称" allow-clear style="width: 160px" />
+    <a-select v-model="mode" style="width: 120px" class="mode-select">
+      <a-option v-for="m in modes" :key="m" :value="m">{{ m }}</a-option>
+    </a-select>
+    <a-button type="primary" size="small" @click="handleSearch">查询</a-button>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const emit = defineEmits<{ (e: 'search', payload: { keyword: string; mode: string }): void }>()
+
+const keyword = ref('')
+const mode = ref('全部')
+const modes = ['全部', '排位', '匹配', '大乱斗']
+
+const handleSearch = () => {
+  emit('search', { keyword: keyword.value.trim(), mode: mode.value })
+}
+</script>
+
+<style scoped lang="less">
+.filter-header {
+  display: flex;
+  gap: 8px;
+  padding: 8px 0;
+  align-items: center;
+}
+.mode-select {
+  min-width: 80px;
+}
+</style>

--- a/frontend/src/views/stats/components/SearchList.vue
+++ b/frontend/src/views/stats/components/SearchList.vue
@@ -1,0 +1,50 @@
+<template>
+  <div class="search-list">
+    <SearchListItem v-for="match in matches" :key="match.id" :match="match" />
+    <div v-if="!matches.length" class="empty">暂无数据</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import SearchListItem from './SearchListItem.vue'
+
+interface MatchDetail {
+  id: number | string
+  result: string
+  mode: string
+  time: string
+  champion: string
+  spells: string[]
+  runes: string[]
+  items: string[]
+  kills: number
+  deaths: number
+  assists: number
+  cs: number
+  gold: number
+  damage: number
+  level: number
+  towers: number
+  inhibitor: number
+  baron: number
+  dragon: number
+  herald: number
+  vilemaw: number
+  map: string
+}
+
+defineProps<{ matches: MatchDetail[] }>()
+</script>
+
+<style scoped lang="less">
+.search-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.empty {
+  text-align: center;
+  color: var(--color-text-3);
+  padding: 20px 0;
+}
+</style>

--- a/frontend/src/views/stats/components/SearchListItem.vue
+++ b/frontend/src/views/stats/components/SearchListItem.vue
@@ -1,0 +1,211 @@
+<template>
+  <a-card class="match-item" :class="{ win: match.result === 'win', lose: match.result === 'lose' }" :bordered="false">
+    <div class="match-content">
+      <div class="left">
+        <div class="avatar-wrapper">
+          <img :src="match.champion" class="champion-avatar" />
+          <span class="level">{{ match.level }}</span>
+        </div>
+        <div class="info-wrapper">
+          <span class="result" :class="match.result">{{ match.result === 'win' ? '胜利' : '失败' }}</span>
+          <span class="mode">{{ match.mode }}</span>
+          <div class="spells">
+            <img v-for="(spell, idx) in match.spells" :key="idx" :src="spell" class="spell-icon" />
+          </div>
+          <div class="runes">
+            <img v-for="(rune, idx) in match.runes" :key="idx" :src="rune" class="rune-icon" />
+          </div>
+        </div>
+      </div>
+      <div class="middle">
+        <div class="kda-line">
+          <strong>{{ match.kills }}</strong> /
+          <strong class="deaths">{{ match.deaths }}</strong> /
+          <strong>{{ match.assists }}</strong>
+        </div>
+        <span class="cs">{{ match.cs }} 补刀</span>
+        <div class="items">
+          <img v-for="(item, idx) in match.items" :key="idx" :src="item" class="item-icon" />
+        </div>
+        <span class="gold">{{ match.gold.toLocaleString() }} 金币</span>
+        <span class="damage">{{ match.damage.toLocaleString() }} 伤害</span>
+      </div>
+      <div class="right">
+        <div class="team-stats">
+          <span>塔 {{ match.towers }}</span>
+          <span>水晶 {{ match.inhibitor }}</span>
+          <span>男爵 {{ match.baron }}</span>
+          <span>巨龙 {{ match.dragon }}</span>
+          <span>先锋 {{ match.herald }}</span>
+          <span>巢虫 {{ match.vilemaw }}</span>
+        </div>
+        <div class="meta">
+          <span class="map">{{ match.map }}</span>
+          <span class="time">{{ match.time }}</span>
+        </div>
+      </div>
+    </div>
+  </a-card>
+</template>
+
+<script setup lang="ts">
+interface MatchDetail {
+  id: number | string
+  result: string
+  mode: string
+  time: string
+  champion: string
+  spells: string[]
+  runes: string[]
+  items: string[]
+  kills: number
+  deaths: number
+  assists: number
+  cs: number
+  gold: number
+  damage: number
+  level: number
+  towers: number
+  inhibitor: number
+  baron: number
+  dragon: number
+  herald: number
+  vilemaw: number
+  map: string
+}
+
+defineProps<{ match: MatchDetail }>()
+</script>
+
+<style scoped lang="less">
+.match-item {
+  border-radius: 6px;
+  padding: 12px;
+  box-shadow: 0 0 4px var(--color-shadow);
+  transition: transform 0.2s;
+  &:hover {
+    transform: translateY(-2px);
+  }
+  &.win {
+    background-color: var(--color-success-light-1);
+    border: 1px solid var(--color-success-light-3);
+  }
+  &.lose {
+    background-color: var(--color-danger-light-1);
+    border: 1px solid var(--color-danger-light-3);
+  }
+  .match-content {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+  .left {
+    display: flex;
+    gap: 12px;
+    .avatar-wrapper {
+      position: relative;
+      .champion-avatar {
+        width: 48px;
+        height: 48px;
+        border-radius: 8px;
+      }
+      .level {
+        position: absolute;
+        bottom: -8px;
+        right: -8px;
+        background: var(--color-bg-1);
+        font-size: 12px;
+        width: 20px;
+        height: 20px;
+        line-height: 20px;
+        text-align: center;
+        border-radius: 50%;
+        box-shadow: 0 0 2px var(--color-shadow);
+      }
+    }
+    .info-wrapper {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      .result {
+        font-weight: bold;
+        font-size: 14px;
+        &.win {
+          color: var(--color-success);
+        }
+        &.lose {
+          color: var(--color-danger);
+        }
+      }
+      .mode {
+        font-size: 12px;
+        color: var(--color-text-2);
+        margin: 2px 0;
+      }
+      .spells,
+      .runes {
+        display: flex;
+        gap: 4px;
+        margin-top: 2px;
+        .spell-icon,
+        .rune-icon {
+          width: 20px;
+          height: 20px;
+          border-radius: 3px;
+        }
+      }
+    }
+  }
+  .middle {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+    .kda-line {
+      font-size: 13px;
+      .deaths {
+        color: var(--color-danger);
+        font-weight: bold;
+      }
+    }
+    .cs,
+    .gold,
+    .damage {
+      font-size: 13px;
+      color: var(--color-text-2);
+    }
+    .items {
+      display: flex;
+      gap: 4px;
+      .item-icon {
+        width: 26px;
+        height: 26px;
+        border-radius: 4px;
+        background-color: var(--color-fill-2);
+      }
+    }
+  }
+  .right {
+    text-align: right;
+    min-width: 120px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    .team-stats {
+      display: flex;
+      flex-direction: column;
+      font-size: 12px;
+      color: var(--color-text-2);
+    }
+    .meta {
+      font-size: 12px;
+      color: var(--color-text-2);
+      margin-top: 4px;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+    }
+  }
+}
+</style>

--- a/frontend/src/views/stats/components/SearchPagination.vue
+++ b/frontend/src/views/stats/components/SearchPagination.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="pagination">
+    <a-pagination
+      :current="page"
+      :total="total"
+      :page-size="pageSize"
+      @change="p => emit('change', p)"
+      size="small"
+      show-jumper
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ page: number; total: number; pageSize?: number }>()
+const emit = defineEmits<{ (e: 'change', page: number): void }>()
+
+const pageSize = props.pageSize ?? 10
+</script>
+
+<style scoped lang="less">
+.pagination {
+  display: flex;
+  justify-content: center;
+  padding: 12px 0;
+}
+</style>

--- a/frontend/src/views/stats/index.vue
+++ b/frontend/src/views/stats/index.vue
@@ -1,16 +1,103 @@
 <template>
-  <div class="search-filter-header">
-    <!-- 筛选组件内容以后填充 -->
-    123123
+  <div class="stats-page">
+    <SearchFilterHeader @search="onSearch" />
+    <SearchList :matches="pageMatches" />
+    <SearchPagination :page="page" :total="total" @change="onPageChange" />
   </div>
 </template>
 
 <script setup lang="ts">
-// 以后在这里写 props, emits, 数据逻辑
+import { ref, computed } from 'vue'
+import SearchFilterHeader from './components/SearchFilterHeader.vue'
+import SearchList from './components/SearchList.vue'
+import SearchPagination from './components/SearchPagination.vue'
+
+interface MatchDetail {
+  id: number | string
+  result: string
+  mode: string
+  time: string
+  champion: string
+  spells: string[]
+  runes: string[]
+  items: string[]
+  kills: number
+  deaths: number
+  assists: number
+  cs: number
+  gold: number
+  damage: number
+  level: number
+  towers: number
+  inhibitor: number
+  baron: number
+  dragon: number
+  herald: number
+  vilemaw: number
+  map: string
+}
+
+const matches = ref<MatchDetail[]>([])
+const page = ref(1)
+const pageSize = 5
+const total = ref(0)
+
+const pageMatches = computed(() => {
+  const start = (page.value - 1) * pageSize
+  return matches.value.slice(start, start + pageSize)
+})
+
+const sampleImg = new URL('@/assets/logo.png', import.meta.url).href
+const mockData: MatchDetail[] = Array.from({ length: 8 }).map((_, idx) => ({
+  id: idx + 1,
+  result: idx % 2 === 0 ? 'win' : 'lose',
+  mode: '匹配模式',
+  time: '2023/01/01 12:00',
+  champion: sampleImg,
+  spells: [sampleImg, sampleImg],
+  runes: [sampleImg, sampleImg],
+  items: [sampleImg, sampleImg, sampleImg, sampleImg, sampleImg, sampleImg],
+  kills: 5,
+  deaths: 3,
+  assists: 8,
+  cs: 120,
+  gold: 12345,
+  damage: 23456,
+  level: 15,
+  towers: 8,
+  inhibitor: 2,
+  baron: 1,
+  dragon: 2,
+  herald: 1,
+  vilemaw: 0,
+  map: '召唤师峡谷'
+}))
+
+function onSearch() {
+  matches.value = mockData
+  total.value = mockData.length
+  page.value = 1
+}
+
+function onPageChange(p: number) {
+  page.value = p
+}
 </script>
 
-<style scoped>
-.search-filter-header {
-  padding: 8px 0;
+<style scoped lang="less">
+.stats-page {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  height: calc(100vh - 32px);
+  overflow: hidden;
+  > *:not(:last-child) {
+    flex-shrink: 0;
+  }
+  .search-list {
+    flex: 1;
+    overflow-y: auto;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- implement stats search page and components

## Testing
- `go test ./...` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685d65866c30832dbb16258f28fca13e